### PR TITLE
Instances now have the profile which permits them to list and get fro…

### DIFF
--- a/application/instance_profile.tf
+++ b/application/instance_profile.tf
@@ -1,0 +1,6 @@
+module "s3_access_role" {
+  source                  = "../modules/iam_roles/server_provision_ec2_role"
+  role_name               = "${var.environment_name}-server-provision-ec2-role"
+  environment_name        = "${var.environment_name}"
+  dependencies_bucket_arn = "${var.dependencies_bucket_arn}"
+}

--- a/application/server-delius-db.tf
+++ b/application/server-delius-db.tf
@@ -1,9 +1,10 @@
 resource "aws_instance" "delius_db" {
-  ami               = "${data.aws_ami.centos.id}"
-  instance_type     = "${var.instance_type_db}"
-  subnet_id         = "${data.terraform_remote_state.vpc.vpc_db-subnet-az1}"
-  key_name          = "${data.terraform_remote_state.vpc.ssh_deployer_key}"
-  source_dest_check = false
+  ami                  = "${data.aws_ami.centos.id}"
+  instance_type        = "${var.instance_type_db}"
+  subnet_id            = "${data.terraform_remote_state.vpc.vpc_db-subnet-az1}"
+  key_name             = "${data.terraform_remote_state.vpc.ssh_deployer_key}"
+  iam_instance_profile = "${module.s3_access_role.instance_profile_ec2_id}"
+  source_dest_check    = false
 
   vpc_security_group_ids = [
     "${data.terraform_remote_state.vpc_security_groups.sg_ssh_bastion_in_id}",

--- a/application/server-oid-db.tf
+++ b/application/server-oid-db.tf
@@ -1,11 +1,12 @@
 #TODO: add oracle RDS for OID
 
 resource "aws_instance" "oid_db" {
-  ami               = "${data.aws_ami.centos.id}"
-  instance_type     = "${var.instance_type_db}"
-  subnet_id         = "${data.terraform_remote_state.vpc.vpc_db-subnet-az1}"
-  key_name          = "${data.terraform_remote_state.vpc.ssh_deployer_key}"
-  source_dest_check = false
+  ami                  = "${data.aws_ami.centos.id}"
+  instance_type        = "${var.instance_type_db}"
+  subnet_id            = "${data.terraform_remote_state.vpc.vpc_db-subnet-az1}"
+  key_name             = "${data.terraform_remote_state.vpc.ssh_deployer_key}"
+  iam_instance_profile = "${module.s3_access_role.instance_profile_ec2_id}"
+  source_dest_check    = false
 
   vpc_security_group_ids = [
     "${data.terraform_remote_state.vpc_security_groups.sg_ssh_bastion_in_id}",

--- a/application/variables.tf
+++ b/application/variables.tf
@@ -34,3 +34,7 @@ variable "instance_type_weblogic" {
 variable "instance_type_db" {
   description = "The ec2 instance type"
 }
+
+variable "dependencies_bucket_arn" {
+  description = "S3 bucket arn for dependencies"
+}

--- a/application/weblogic-interface.tf
+++ b/application/weblogic-interface.tf
@@ -27,16 +27,17 @@ module "interface" {
     data.terraform_remote_state.vpc.vpc_public-subnet-az3,
   )}"
 
-  tags              = "${data.terraform_remote_state.vpc.tags}"
-  environment_name  = "${var.environment_name}"
-  vpc_id            = "${data.terraform_remote_state.vpc.vpc_id}"
-  key_name          = "${data.terraform_remote_state.vpc.ssh_deployer_key}"
-  kms_key_id        = "${module.kms_key_app.kms_arn}"
-  public_zone_id    = "${data.terraform_remote_state.vpc.public_zone_id}"
-  private_zone_id   = "${data.terraform_remote_state.vpc.public_zone_id}"
-  ami_id            = "${data.aws_ami.centos_wls.id}"
-  managed_elb_sg_id = "${data.terraform_remote_state.delius_core_security_groups.sg_weblogic_interface_managed_elb_id}"
-  admin_elb_sg_id   = "${data.terraform_remote_state.delius_core_security_groups.sg_weblogic_interface_admin_elb_id}"
+  tags                 = "${data.terraform_remote_state.vpc.tags}"
+  environment_name     = "${var.environment_name}"
+  vpc_id               = "${data.terraform_remote_state.vpc.vpc_id}"
+  key_name             = "${data.terraform_remote_state.vpc.ssh_deployer_key}"
+  kms_key_id           = "${module.kms_key_app.kms_arn}"
+  public_zone_id       = "${data.terraform_remote_state.vpc.public_zone_id}"
+  private_zone_id      = "${data.terraform_remote_state.vpc.public_zone_id}"
+  ami_id               = "${data.aws_ami.centos_wls.id}"
+  managed_elb_sg_id    = "${data.terraform_remote_state.delius_core_security_groups.sg_weblogic_interface_managed_elb_id}"
+  admin_elb_sg_id      = "${data.terraform_remote_state.delius_core_security_groups.sg_weblogic_interface_admin_elb_id}"
+  iam_instance_profile = "${module.s3_access_role.instance_profile_ec2_id}"
 }
 
 output "internal_fqdn_interface_admin" {

--- a/application/weblogic-ndelius.tf
+++ b/application/weblogic-ndelius.tf
@@ -27,16 +27,17 @@ module "ndelius" {
     data.terraform_remote_state.vpc.vpc_public-subnet-az3,
   )}"
 
-  tags              = "${data.terraform_remote_state.vpc.tags}"
-  environment_name  = "${var.environment_name}"
-  vpc_id            = "${data.terraform_remote_state.vpc.vpc_id}"
-  key_name          = "${data.terraform_remote_state.vpc.ssh_deployer_key}"
-  kms_key_id        = "${module.kms_key_app.kms_arn}"
-  public_zone_id    = "${data.terraform_remote_state.vpc.public_zone_id}"
-  private_zone_id   = "${data.terraform_remote_state.vpc.public_zone_id}"
-  ami_id            = "${data.aws_ami.centos_wls.id}"
-  managed_elb_sg_id = "${data.terraform_remote_state.delius_core_security_groups.sg_weblogic_ndelius_managed_elb_id}"
-  admin_elb_sg_id   = "${data.terraform_remote_state.delius_core_security_groups.sg_weblogic_ndelius_admin_elb_id}"
+  tags                 = "${data.terraform_remote_state.vpc.tags}"
+  environment_name     = "${var.environment_name}"
+  vpc_id               = "${data.terraform_remote_state.vpc.vpc_id}"
+  key_name             = "${data.terraform_remote_state.vpc.ssh_deployer_key}"
+  kms_key_id           = "${module.kms_key_app.kms_arn}"
+  public_zone_id       = "${data.terraform_remote_state.vpc.public_zone_id}"
+  private_zone_id      = "${data.terraform_remote_state.vpc.public_zone_id}"
+  ami_id               = "${data.aws_ami.centos_wls.id}"
+  managed_elb_sg_id    = "${data.terraform_remote_state.delius_core_security_groups.sg_weblogic_ndelius_managed_elb_id}"
+  admin_elb_sg_id      = "${data.terraform_remote_state.delius_core_security_groups.sg_weblogic_ndelius_admin_elb_id}"
+  iam_instance_profile = "${module.s3_access_role.instance_profile_ec2_id}"
 }
 
 output "internal_fqdn_ndelius_admin" {

--- a/application/weblogic-oid.tf
+++ b/application/weblogic-oid.tf
@@ -27,16 +27,17 @@ module "oid" {
     data.terraform_remote_state.vpc.vpc_public-subnet-az3,
   )}"
 
-  tags              = "${data.terraform_remote_state.vpc.tags}"
-  environment_name  = "${var.environment_name}"
-  vpc_id            = "${data.terraform_remote_state.vpc.vpc_id}"
-  key_name          = "${data.terraform_remote_state.vpc.ssh_deployer_key}"
-  kms_key_id        = "${module.kms_key_app.kms_arn}"
-  public_zone_id    = "${data.terraform_remote_state.vpc.public_zone_id}"
-  private_zone_id   = "${data.terraform_remote_state.vpc.public_zone_id}"
-  ami_id            = "${data.aws_ami.centos.id}"
-  managed_elb_sg_id = "${data.terraform_remote_state.delius_core_security_groups.sg_weblogic_oid_managed_elb_id}"
-  admin_elb_sg_id   = "${data.terraform_remote_state.delius_core_security_groups.sg_weblogic_oid_admin_elb_id}"
+  tags                 = "${data.terraform_remote_state.vpc.tags}"
+  environment_name     = "${var.environment_name}"
+  vpc_id               = "${data.terraform_remote_state.vpc.vpc_id}"
+  key_name             = "${data.terraform_remote_state.vpc.ssh_deployer_key}"
+  kms_key_id           = "${module.kms_key_app.kms_arn}"
+  public_zone_id       = "${data.terraform_remote_state.vpc.public_zone_id}"
+  private_zone_id      = "${data.terraform_remote_state.vpc.public_zone_id}"
+  ami_id               = "${data.aws_ami.centos.id}"
+  managed_elb_sg_id    = "${data.terraform_remote_state.delius_core_security_groups.sg_weblogic_oid_managed_elb_id}"
+  admin_elb_sg_id      = "${data.terraform_remote_state.delius_core_security_groups.sg_weblogic_oid_admin_elb_id}"
+  iam_instance_profile = "${module.s3_access_role.instance_profile_ec2_id}"
 }
 
 output "internal_fqdn_oid_admin" {

--- a/application/weblogic-spg.tf
+++ b/application/weblogic-spg.tf
@@ -27,16 +27,17 @@ module "spg" {
     data.terraform_remote_state.vpc.vpc_public-subnet-az3,
   )}"
 
-  tags              = "${data.terraform_remote_state.vpc.tags}"
-  environment_name  = "${var.environment_name}"
-  vpc_id            = "${data.terraform_remote_state.vpc.vpc_id}"
-  key_name          = "${data.terraform_remote_state.vpc.ssh_deployer_key}"
-  kms_key_id        = "${module.kms_key_app.kms_arn}"
-  public_zone_id    = "${data.terraform_remote_state.vpc.public_zone_id}"
-  private_zone_id   = "${data.terraform_remote_state.vpc.public_zone_id}"
-  ami_id            = "${data.aws_ami.centos_wls.id}"
-  managed_elb_sg_id = "${data.terraform_remote_state.delius_core_security_groups.sg_weblogic_spg_managed_elb_id}"
-  admin_elb_sg_id   = "${data.terraform_remote_state.delius_core_security_groups.sg_weblogic_spg_admin_elb_id}"
+  tags                 = "${data.terraform_remote_state.vpc.tags}"
+  environment_name     = "${var.environment_name}"
+  vpc_id               = "${data.terraform_remote_state.vpc.vpc_id}"
+  key_name             = "${data.terraform_remote_state.vpc.ssh_deployer_key}"
+  kms_key_id           = "${module.kms_key_app.kms_arn}"
+  public_zone_id       = "${data.terraform_remote_state.vpc.public_zone_id}"
+  private_zone_id      = "${data.terraform_remote_state.vpc.public_zone_id}"
+  ami_id               = "${data.aws_ami.centos_wls.id}"
+  managed_elb_sg_id    = "${data.terraform_remote_state.delius_core_security_groups.sg_weblogic_spg_managed_elb_id}"
+  admin_elb_sg_id      = "${data.terraform_remote_state.delius_core_security_groups.sg_weblogic_spg_admin_elb_id}"
+  iam_instance_profile = "${module.s3_access_role.instance_profile_ec2_id}"
 }
 
 output "internal_fqdn_spg_admin" {

--- a/env_configs/common.tfvars
+++ b/env_configs/common.tfvars
@@ -16,3 +16,8 @@ weblogic_domain_ports = {
 #SPG has activeMQ running incomming
 #database talks to activemq on spg weblogic domain
 #spg talks to spg-weblogic-domain over activemq
+#  # engineering
+# dependencies_bucket_arn = "arn:aws:s3:::tf-eu-west-2-hmpps-eng-dev-artefacts-s3bucket"
+
+# dev
+dependencies_bucket_arn = "arn:aws:s3:::tf-eu-west-2-hmpps-eng-dev-delius-core-dependencies-s3bucket"

--- a/env_configs/delius-core-dev.tfvars
+++ b/env_configs/delius-core-dev.tfvars
@@ -1,3 +1,6 @@
 instance_type_weblogic = "t2.large"
 
 instance_type_db = "t2.large"
+
+egress_443 = true
+egress_80 = true

--- a/modules/iam_roles/server_provision_ec2_role/output.tf
+++ b/modules/iam_roles/server_provision_ec2_role/output.tf
@@ -1,0 +1,3 @@
+output "instance_profile_ec2_id" {
+  value = "${aws_iam_instance_profile.ec2.id}"
+}

--- a/modules/weblogic/admin.tf
+++ b/modules/weblogic/admin.tf
@@ -1,11 +1,12 @@
 # Admin server (TODO: ASG of one)
 
 resource "aws_instance" "admin" {
-  ami               = "${var.ami_id}"
-  instance_type     = "${var.admin_instance_type}"
-  subnet_id         = "${var.private_subnet}"
-  key_name          = "${var.key_name}"
-  source_dest_check = false
+  ami                  = "${var.ami_id}"
+  instance_type        = "${var.admin_instance_type}"
+  subnet_id            = "${var.private_subnet}"
+  key_name             = "${var.key_name}"
+  iam_instance_profile = "${var.iam_instance_profile}"
+  source_dest_check    = false
 
   vpc_security_group_ids = ["${var.admin_security_groups}"]
 

--- a/modules/weblogic/managed.tf
+++ b/modules/weblogic/managed.tf
@@ -1,11 +1,12 @@
 # Managed server (TODO: ASG)
 
 resource "aws_instance" "managed" {
-  ami               = "${var.ami_id}"
-  instance_type     = "${var.managed_instance_type}"
-  subnet_id         = "${var.private_subnet}"
-  key_name          = "${var.key_name}"
-  source_dest_check = false
+  ami                  = "${var.ami_id}"
+  instance_type        = "${var.managed_instance_type}"
+  subnet_id            = "${var.private_subnet}"
+  key_name             = "${var.key_name}"
+  iam_instance_profile = "${var.iam_instance_profile}"
+  source_dest_check    = false
 
   vpc_security_group_ids = ["${var.managed_security_groups}"]
 

--- a/modules/weblogic/variables.tf
+++ b/modules/weblogic/variables.tf
@@ -92,3 +92,8 @@ variable "ami_id" {
   description = "AWS AMI ID"
   type        = "string"
 }
+
+variable "iam_instance_profile" {
+  description = "iam instance profile id"
+  type        = "string"
+}

--- a/security-groups/delius-db-in.tf
+++ b/security-groups/delius-db-in.tf
@@ -68,3 +68,29 @@ resource "aws_security_group_rule" "weblogic_spg_admin_db_in" {
   to_port                  = "1521"
   source_security_group_id = "${aws_security_group.weblogic_spg_admin.id}"
 }
+
+# This is a temp solution to enable quick access to yum repos from dev env
+# during discovery.
+resource "aws_security_group_rule" "delius_db_egress_80" {
+  count             = "${var.egress_80}"
+  security_group_id = "${aws_security_group.delius_db_in.id}"
+  type              = "egress"
+  protocol          = "tcp"
+  from_port         = 80
+  to_port           = 80
+  cidr_blocks       = ["0.0.0.0/0"]
+  description       = "yum repos"
+}
+
+# This is a temp solution to enable quick access to S3 bucket from dev env
+# during discovery.
+resource "aws_security_group_rule" "delius_db_egress_443" {
+  count             = "${var.egress_443}"
+  security_group_id = "${aws_security_group.delius_db_in.id}"
+  type              = "egress"
+  protocol          = "tcp"
+  from_port         = 443
+  to_port           = 443
+  cidr_blocks       = ["0.0.0.0/0"]
+  description       = "s3"
+}

--- a/security-groups/oid-db-out.tf
+++ b/security-groups/oid-db-out.tf
@@ -26,3 +26,27 @@ output "sg_oid_db_out_id" {
 #   from_port         = "61616"
 #   to_port           = "61617"
 # }
+
+# This is a temp solution to enable quick access to yum repos from dev env
+# during discovery.
+resource "aws_security_group_rule" "oid_db_egress_80" {
+  count             = "${var.egress_80}"
+  security_group_id = "${aws_security_group.oid_db_out.id}"
+  type              = "egress"
+  protocol          = "tcp"
+  from_port         = 80
+  to_port           = 80
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+# This is a temp solution to enable quick access to S3 bucket from dev env
+# during discovery.
+resource "aws_security_group_rule" "oid_db_egress_443" {
+  count             = "${var.egress_443}"
+  security_group_id = "${aws_security_group.oid_db_out.id}"
+  type              = "egress"
+  protocol          = "tcp"
+  from_port         = 443
+  to_port           = 443
+  cidr_blocks       = ["0.0.0.0/0"]
+}

--- a/security-groups/variables.tf
+++ b/security-groups/variables.tf
@@ -18,3 +18,13 @@ variable "weblogic_domain_ports" {
   type        = "map"
   description = "Map of the ports that the weblogic domains use"
 }
+
+variable "egress_80" {
+  description = "Enable sg rule for egress to port 80"
+  default     = false
+}
+
+variable "egress_443" {
+  description = "Enable sg rule for egress to port 433"
+  default     = false
+}

--- a/security-groups/weblogic-interface.tf
+++ b/security-groups/weblogic-interface.tf
@@ -48,7 +48,7 @@ resource "aws_security_group_rule" "wiae_admin_elb_in" {
   protocol          = "tcp"
   from_port         = "${var.weblogic_domain_ports["interface_admin"]}"
   to_port           = "${var.weblogic_domain_ports["interface_admin"]}"
-  cidr_blocks       = [ "${values(data.terraform_remote_state.vpc.bastion_vpc_public_cidr)}" ]
+  cidr_blocks       = ["${values(data.terraform_remote_state.vpc.bastion_vpc_public_cidr)}"]
 }
 
 resource "aws_security_group" "weblogic_interface_admin" {

--- a/security-groups/weblogic-ndelius.tf
+++ b/security-groups/weblogic-ndelius.tf
@@ -48,7 +48,7 @@ resource "aws_security_group_rule" "wnae_admin_elb_in" {
   protocol          = "tcp"
   from_port         = "${var.weblogic_domain_ports["ndelius_admin"]}"
   to_port           = "${var.weblogic_domain_ports["ndelius_admin"]}"
-  cidr_blocks       = [ "${values(data.terraform_remote_state.vpc.bastion_vpc_public_cidr)}" ]
+  cidr_blocks       = ["${values(data.terraform_remote_state.vpc.bastion_vpc_public_cidr)}"]
 }
 
 resource "aws_security_group" "weblogic_ndelius_admin" {

--- a/security-groups/weblogic-oid.tf
+++ b/security-groups/weblogic-oid.tf
@@ -66,7 +66,7 @@ resource "aws_security_group_rule" "woae_admin_elb_in" {
   protocol          = "tcp"
   from_port         = "${var.weblogic_domain_ports["oid_admin"]}"
   to_port           = "${var.weblogic_domain_ports["oid_admin"]}"
-  cidr_blocks       = [ "${values(data.terraform_remote_state.vpc.bastion_vpc_public_cidr)}" ]
+  cidr_blocks       = ["${values(data.terraform_remote_state.vpc.bastion_vpc_public_cidr)}"]
 }
 
 resource "aws_security_group" "weblogic_oid_admin" {

--- a/security-groups/weblogic-spg.tf
+++ b/security-groups/weblogic-spg.tf
@@ -48,7 +48,7 @@ resource "aws_security_group_rule" "wsae_admin_elb_in" {
   protocol          = "tcp"
   from_port         = "${var.weblogic_domain_ports["spg_admin"]}"
   to_port           = "${var.weblogic_domain_ports["spg_admin"]}"
-  cidr_blocks       = [ "${values(data.terraform_remote_state.vpc.bastion_vpc_public_cidr)}" ]
+  cidr_blocks       = ["${values(data.terraform_remote_state.vpc.bastion_vpc_public_cidr)}"]
 }
 
 resource "aws_security_group" "weblogic_spg_admin" {
@@ -76,6 +76,32 @@ resource "aws_security_group_rule" "wsae_admin_elb" {
   source_security_group_id = "${aws_security_group.weblogic_spg_admin_elb.id}"
 }
 
+# This is a temp solution to enable quick access to yum repos from dev env
+# during discovery.
+resource "aws_security_group_rule" "spg_admin_egress_80" {
+  count             = "${var.egress_80}"
+  security_group_id = "${aws_security_group.weblogic_spg_admin.id}"
+  type              = "egress"
+  protocol          = "tcp"
+  from_port         = 80
+  to_port           = 80
+  cidr_blocks       = ["0.0.0.0/0"]
+  description       = "yum repos"
+}
+
+# This is a temp solution to enable quick access to S3 bucket from dev env
+# during discovery.
+resource "aws_security_group_rule" "spg_admin_egress_443" {
+  count             = "${var.egress_443}"
+  security_group_id = "${aws_security_group.weblogic_spg_admin.id}"
+  type              = "egress"
+  protocol          = "tcp"
+  from_port         = 443
+  to_port           = 443
+  cidr_blocks       = ["0.0.0.0/0"]
+  description       = "s3"
+}
+
 resource "aws_security_group" "weblogic_spg_managed" {
   name        = "${var.environment_name}-weblogic-spg-managed"
   vpc_id      = "${data.terraform_remote_state.vpc.vpc_id}"
@@ -99,4 +125,30 @@ resource "aws_security_group_rule" "spg_elb" {
   from_port                = "${var.weblogic_domain_ports["spg_managed"]}"
   to_port                  = "${var.weblogic_domain_ports["spg_managed"]}"
   source_security_group_id = "${aws_security_group.weblogic_spg_managed_elb.id}"
+}
+
+# This is a temp solution to enable quick access to yum repos from dev env
+# during discovery.
+resource "aws_security_group_rule" "spg_egress_80" {
+  count             = "${var.egress_80}"
+  security_group_id = "${aws_security_group.weblogic_spg_managed.id}"
+  type              = "egress"
+  protocol          = "tcp"
+  from_port         = 80
+  to_port           = 80
+  cidr_blocks       = ["0.0.0.0/0"]
+  description       = "yum repos"
+}
+
+# This is a temp solution to enable quick access to S3 bucket from dev env
+# during discovery.
+resource "aws_security_group_rule" "spg_egress_443" {
+  count             = "${var.egress_443}"
+  security_group_id = "${aws_security_group.weblogic_spg_managed.id}"
+  type              = "egress"
+  protocol          = "tcp"
+  from_port         = 443
+  to_port           = 443
+  cidr_blocks       = ["0.0.0.0/0"]
+  description       = "s3"
 }


### PR DESCRIPTION
…m the "tf-eu-west-2-hmpps-eng-dev-delius-core-dependencies-s3bucket" created in the engineering environment previously for private access to S3 storage.

Database and SPG admin and managed instances have a pair of security rules to allow egress on ports 80 and 443 conditionally in the dev environment.
NOTE: access out and to S3 should not be necessary outside of dev env.