### PR TITLE
Feature/complete basic security group rules

### DIFF
--- a/application/main.tf
+++ b/application/main.tf
@@ -116,7 +116,8 @@ data "aws_ami" "centos_oracle_db" {
   filter {
     name   = "name"
     #values = ["HMPPS Delius-Core OracleDB master *"]
-    values = ["HMPPS Delius-Core OracleDB feature/oracleDB 1538137829"]
+    #values = ["HMPPS Delius-Core OracleDB feature/oracleDB 1538137829"]
+    values = ["HMPPS Delius-Core OracleDB feature/oracleDB 1538147935"]
   }
 
   filter {

--- a/application/main.tf
+++ b/application/main.tf
@@ -115,9 +115,7 @@ data "aws_ami" "centos_oracle_db" {
 
   filter {
     name   = "name"
-    #values = ["HMPPS Delius-Core OracleDB master *"]
-    #values = ["HMPPS Delius-Core OracleDB feature/oracleDB 1538137829"]
-    values = ["HMPPS Delius-Core OracleDB feature/oracleDB 1538147935"]
+    values = ["HMPPS Delius-Core OracleDB master *"]
   }
 
   filter {

--- a/application/server-delius-db.tf
+++ b/application/server-delius-db.tf
@@ -9,6 +9,7 @@ resource "aws_instance" "delius_db" {
   vpc_security_group_ids = [
     "${data.terraform_remote_state.vpc_security_groups.sg_ssh_bastion_in_id}",
     "${data.terraform_remote_state.delius_core_security_groups.sg_delius_db_in_id}",
+    "${data.terraform_remote_state.delius_core_security_groups.sg_delius_db_out_id}",
   ]
 
   root_block_device = {

--- a/application/server-oid-db.tf
+++ b/application/server-oid-db.tf
@@ -11,6 +11,7 @@ resource "aws_instance" "oid_db" {
   vpc_security_group_ids = [
     "${data.terraform_remote_state.vpc_security_groups.sg_ssh_bastion_in_id}",
     "${data.terraform_remote_state.delius_core_security_groups.sg_oid_db_in_id}",
+    "${data.terraform_remote_state.delius_core_security_groups.sg_oid_db_out_id}",
   ]
 
   root_block_device = {

--- a/security-groups/delius-db-in.tf
+++ b/security-groups/delius-db-in.tf
@@ -68,29 +68,3 @@ resource "aws_security_group_rule" "weblogic_spg_admin_db_in" {
   to_port                  = "1521"
   source_security_group_id = "${aws_security_group.weblogic_spg_admin.id}"
 }
-
-# This is a temp solution to enable quick access to yum repos from dev env
-# during discovery.
-resource "aws_security_group_rule" "delius_db_egress_80" {
-  count             = "${var.egress_80}"
-  security_group_id = "${aws_security_group.delius_db_in.id}"
-  type              = "egress"
-  protocol          = "tcp"
-  from_port         = 80
-  to_port           = 80
-  cidr_blocks       = ["0.0.0.0/0"]
-  description       = "yum repos"
-}
-
-# This is a temp solution to enable quick access to S3 bucket from dev env
-# during discovery.
-resource "aws_security_group_rule" "delius_db_egress_443" {
-  count             = "${var.egress_443}"
-  security_group_id = "${aws_security_group.delius_db_in.id}"
-  type              = "egress"
-  protocol          = "tcp"
-  from_port         = 443
-  to_port           = 443
-  cidr_blocks       = ["0.0.0.0/0"]
-  description       = "s3"
-}

--- a/security-groups/delius-db-in.tf
+++ b/security-groups/delius-db-in.tf
@@ -1,5 +1,8 @@
 # delius-db-in.tf
 
+################################################################################
+## delius_db_in
+################################################################################
 resource "aws_security_group" "delius_db_in" {
   name        = "${var.environment_name}-delius-db-in"
   vpc_id      = "${data.terraform_remote_state.vpc.vpc_id}"
@@ -22,6 +25,7 @@ resource "aws_security_group_rule" "weblogic_interface_managed_db_in" {
   from_port                = "1521"
   to_port                  = "1521"
   source_security_group_id = "${aws_security_group.weblogic_interface_managed.id}"
+  description              = "wls interface managed"
 }
 
 resource "aws_security_group_rule" "weblogic_interface_admin_db_in" {
@@ -31,6 +35,7 @@ resource "aws_security_group_rule" "weblogic_interface_admin_db_in" {
   from_port                = "1521"
   to_port                  = "1521"
   source_security_group_id = "${aws_security_group.weblogic_interface_admin.id}"
+  description              = "wls interface admin"
 }
 
 resource "aws_security_group_rule" "weblogic_ndelius_managed_db_in" {
@@ -40,6 +45,7 @@ resource "aws_security_group_rule" "weblogic_ndelius_managed_db_in" {
   from_port                = "1521"
   to_port                  = "1521"
   source_security_group_id = "${aws_security_group.weblogic_ndelius_managed.id}"
+  description              = "wls ndelius managed"
 }
 
 resource "aws_security_group_rule" "weblogic_ndelius_admin_db_in" {
@@ -49,6 +55,7 @@ resource "aws_security_group_rule" "weblogic_ndelius_admin_db_in" {
   from_port                = "1521"
   to_port                  = "1521"
   source_security_group_id = "${aws_security_group.weblogic_ndelius_admin.id}"
+  description              = "wls ndelius admin"
 }
 
 resource "aws_security_group_rule" "weblogic_spg_managed_db_in" {
@@ -58,6 +65,7 @@ resource "aws_security_group_rule" "weblogic_spg_managed_db_in" {
   from_port                = "1521"
   to_port                  = "1521"
   source_security_group_id = "${aws_security_group.weblogic_spg_managed.id}"
+  description              = "wls spg managed"
 }
 
 resource "aws_security_group_rule" "weblogic_spg_admin_db_in" {
@@ -67,4 +75,5 @@ resource "aws_security_group_rule" "weblogic_spg_admin_db_in" {
   from_port                = "1521"
   to_port                  = "1521"
   source_security_group_id = "${aws_security_group.weblogic_spg_admin.id}"
+  description              = "wls spg admin"
 }

--- a/security-groups/delius-db-out.tf
+++ b/security-groups/delius-db-out.tf
@@ -1,0 +1,42 @@
+# delius-db-out.tf
+
+resource "aws_security_group" "delius_db_out" {
+  name        = "${var.environment_name}-delius-db-out"
+  vpc_id      = "${data.terraform_remote_state.vpc.vpc_id}"
+  description = "Delius database in"
+  tags        = "${merge(data.terraform_remote_state.vpc.tags, map("Name", "${var.environment_name}-delius-db-out", "Type", "DB"))}"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+output "sg_delius_db_out_id" {
+  value = "${aws_security_group.delius_db_out.id}"
+}
+
+# This is a temp solution to enable quick access to yum repos from dev env
+# during discovery.
+resource "aws_security_group_rule" "delius_db_out_80" {
+  count             = "${var.egress_80}"
+  security_group_id = "${aws_security_group.delius_db_out.id}"
+  type              = "egress"
+  protocol          = "tcp"
+  from_port         = 80
+  to_port           = 80
+  cidr_blocks       = ["0.0.0.0/0"]
+  description       = "tmp yum repos"
+}
+
+# This is a temp solution to enable quick access to S3 bucket from dev env
+# during discovery.
+resource "aws_security_group_rule" "delius_db_out_443" {
+  count             = "${var.egress_443}"
+  security_group_id = "${aws_security_group.delius_db_out.id}"
+  type              = "egress"
+  protocol          = "tcp"
+  from_port         = 443
+  to_port           = 443
+  cidr_blocks       = ["0.0.0.0/0"]
+  description       = "tmp s3"
+}

--- a/security-groups/delius-db-out.tf
+++ b/security-groups/delius-db-out.tf
@@ -1,5 +1,8 @@
 # delius-db-out.tf
 
+################################################################################
+## delius_db_out
+################################################################################
 resource "aws_security_group" "delius_db_out" {
   name        = "${var.environment_name}-delius-db-out"
   vpc_id      = "${data.terraform_remote_state.vpc.vpc_id}"

--- a/security-groups/oid-db-in.tf
+++ b/security-groups/oid-db-in.tf
@@ -1,5 +1,8 @@
 # oid-db-in.tf
 
+################################################################################
+## oid_db_in
+################################################################################
 resource "aws_security_group" "oid_db_in" {
   name        = "${var.environment_name}-oid-db-in"
   vpc_id      = "${data.terraform_remote_state.vpc.vpc_id}"
@@ -22,6 +25,7 @@ resource "aws_security_group_rule" "weblogic_oid_managed_db_in" {
   from_port                = "1521"
   to_port                  = "1521"
   source_security_group_id = "${aws_security_group.weblogic_oid_managed.id}"
+  description              = "wls oid managed"
 }
 
 resource "aws_security_group_rule" "weblogic_oid_admin_db_in" {
@@ -31,4 +35,5 @@ resource "aws_security_group_rule" "weblogic_oid_admin_db_in" {
   from_port                = "1521"
   to_port                  = "1521"
   source_security_group_id = "${aws_security_group.weblogic_oid_admin.id}"
+  description              = "wls oid admin"
 }

--- a/security-groups/oid-db-out.tf
+++ b/security-groups/oid-db-out.tf
@@ -1,5 +1,8 @@
 # oid-db-out.tf
 
+################################################################################
+## oid_db_out
+################################################################################
 resource "aws_security_group" "oid_db_out" {
   name        = "${var.environment_name}-oid-db-out"
   vpc_id      = "${data.terraform_remote_state.vpc.vpc_id}"
@@ -37,6 +40,7 @@ resource "aws_security_group_rule" "oid_db_egress_80" {
   from_port         = 80
   to_port           = 80
   cidr_blocks       = ["0.0.0.0/0"]
+  description       = "yum repos"
 }
 
 # This is a temp solution to enable quick access to S3 bucket from dev env
@@ -49,4 +53,5 @@ resource "aws_security_group_rule" "oid_db_egress_443" {
   from_port         = 443
   to_port           = 443
   cidr_blocks       = ["0.0.0.0/0"]
+  description       = "s3"
 }

--- a/security-groups/weblogic-interface.tf
+++ b/security-groups/weblogic-interface.tf
@@ -98,6 +98,32 @@ resource "aws_security_group_rule" "interface_admin_egress_1521" {
   description              = "Delius db out"
 }
 
+# This is a temp solution to enable quick access to yum repos from dev env
+# during discovery.
+resource "aws_security_group_rule" "interface_admin_egress_80" {
+  count             = "${var.egress_80}"
+  security_group_id = "${aws_security_group.weblogic_interface_admin.id}"
+  type              = "egress"
+  protocol          = "tcp"
+  from_port         = 80
+  to_port           = 80
+  cidr_blocks       = ["0.0.0.0/0"]
+  description       = "yum repos"
+}
+
+# This is a temp solution to enable quick access to S3 bucket from dev env
+# during discovery.
+resource "aws_security_group_rule" "interface_admin_egress_443" {
+  count             = "${var.egress_443}"
+  security_group_id = "${aws_security_group.weblogic_interface_admin.id}"
+  type              = "egress"
+  protocol          = "tcp"
+  from_port         = 443
+  to_port           = 443
+  cidr_blocks       = ["0.0.0.0/0"]
+  description       = "s3"
+}
+
 ################################################################################
 ## weblogic_interface_managed
 ################################################################################
@@ -135,4 +161,40 @@ resource "aws_security_group_rule" "interface_managed_egress_1521" {
   to_port                  = 1521
   source_security_group_id = "${aws_security_group.delius_db_in.id}"
   description              = "Delius db out"
+}
+
+resource "aws_security_group_rule" "interface_managed_egress_oid_ldap" {
+  security_group_id        = "${aws_security_group.weblogic_interface_managed.id}"
+  type                     = "egress"
+  protocol                 = "tcp"
+  from_port                = "${var.weblogic_domain_ports["oid_ldap"]}"
+  to_port                  = "${var.weblogic_domain_ports["oid_ldap"]}"
+  source_security_group_id = "${aws_security_group.weblogic_oid_managed_elb.id}"
+  description              = "OID LDAP out"
+}
+
+# This is a temp solution to enable quick access to yum repos from dev env
+# during discovery.
+resource "aws_security_group_rule" "interface_managed_egress_80" {
+  count             = "${var.egress_80}"
+  security_group_id = "${aws_security_group.weblogic_interface_managed.id}"
+  type              = "egress"
+  protocol          = "tcp"
+  from_port         = 80
+  to_port           = 80
+  cidr_blocks       = ["0.0.0.0/0"]
+  description       = "yum repos"
+}
+
+# This is a temp solution to enable quick access to S3 bucket from dev env
+# during discovery.
+resource "aws_security_group_rule" "interface_managed_egress_443" {
+  count             = "${var.egress_443}"
+  security_group_id = "${aws_security_group.weblogic_interface_managed.id}"
+  type              = "egress"
+  protocol          = "tcp"
+  from_port         = 443
+  to_port           = 443
+  cidr_blocks       = ["0.0.0.0/0"]
+  description       = "s3"
 }

--- a/security-groups/weblogic-interface.tf
+++ b/security-groups/weblogic-interface.tf
@@ -1,5 +1,8 @@
 # weblogic-interface.tf
 
+################################################################################
+## weblogic_interface_managed_elb
+################################################################################
 resource "aws_security_group" "weblogic_interface_managed_elb" {
   name        = "${var.environment_name}-weblogic-interface-managed-elb"
   vpc_id      = "${data.terraform_remote_state.vpc.vpc_id}"
@@ -17,15 +20,19 @@ output "sg_weblogic_interface_managed_elb_id" {
 
 #Allow users into the managed boxes on the useful port
 #TODO: Do we build a list of allowed source in or?
-resource "aws_security_group_rule" "wime_managed_elb_in" {
+resource "aws_security_group_rule" "interface_managed_elb_ingress" {
   security_group_id = "${aws_security_group.weblogic_interface_managed_elb.id}"
   type              = "ingress"
   protocol          = "tcp"
   from_port         = "${var.weblogic_domain_ports["interface_managed"]}"
   to_port           = "${var.weblogic_domain_ports["interface_managed"]}"
   cidr_blocks       = ["0.0.0.0/0"]
+  description       = "World in"
 }
 
+################################################################################
+## weblogic_interface_admin_elb
+################################################################################
 resource "aws_security_group" "weblogic_interface_admin_elb" {
   name        = "${var.environment_name}-weblogic-interface-admin-elb"
   vpc_id      = "${data.terraform_remote_state.vpc.vpc_id}"
@@ -42,15 +49,19 @@ output "sg_weblogic_interface_admin_elb_id" {
 }
 
 #Allow admins into the admin box
-resource "aws_security_group_rule" "wiae_admin_elb_in" {
+resource "aws_security_group_rule" "interface_admin_elb_ingress" {
   security_group_id = "${aws_security_group.weblogic_interface_admin_elb.id}"
   type              = "ingress"
   protocol          = "tcp"
   from_port         = "${var.weblogic_domain_ports["interface_admin"]}"
   to_port           = "${var.weblogic_domain_ports["interface_admin"]}"
   cidr_blocks       = ["${values(data.terraform_remote_state.vpc.bastion_vpc_public_cidr)}"]
+  description       = "Admins in via bastion"
 }
 
+################################################################################
+## weblogic_interface_admin
+################################################################################
 resource "aws_security_group" "weblogic_interface_admin" {
   name        = "${var.environment_name}-weblogic-interface-admin"
   vpc_id      = "${data.terraform_remote_state.vpc.vpc_id}"
@@ -67,15 +78,29 @@ output "sg_weblogic_interface_admin_id" {
 }
 
 #Allow the ELB into the Admin port
-resource "aws_security_group_rule" "wia_admin_elb" {
+resource "aws_security_group_rule" "interface_admin_elb_elb_ingress" {
   security_group_id        = "${aws_security_group.weblogic_interface_admin.id}"
   type                     = "ingress"
   protocol                 = "tcp"
   from_port                = "${var.weblogic_domain_ports["interface_admin"]}"
   to_port                  = "${var.weblogic_domain_ports["interface_admin"]}"
   source_security_group_id = "${aws_security_group.weblogic_interface_admin_elb.id}"
+  description              = "Admins via ELB in"
 }
 
+resource "aws_security_group_rule" "interface_admin_egress_1521" {
+  security_group_id        = "${aws_security_group.weblogic_interface_admin.id}"
+  type                     = "egress"
+  protocol                 = "tcp"
+  from_port                = 1521
+  to_port                  = 1521
+  source_security_group_id = "${aws_security_group.delius_db_in.id}"
+  description              = "Delius db out"
+}
+
+################################################################################
+## weblogic_interface_managed
+################################################################################
 resource "aws_security_group" "weblogic_interface_managed" {
   name        = "${var.environment_name}-weblogic-interface-managed"
   vpc_id      = "${data.terraform_remote_state.vpc.vpc_id}"
@@ -92,11 +117,22 @@ output "sg_weblogic_interface_managed_id" {
 }
 
 #Allow the ELB into the managed port
-resource "aws_security_group_rule" "interface_elb" {
+resource "aws_security_group_rule" "interface_managed_elb_elb_ingress" {
   security_group_id        = "${aws_security_group.weblogic_interface_managed.id}"
   type                     = "ingress"
   protocol                 = "tcp"
   from_port                = "${var.weblogic_domain_ports["interface_managed"]}"
   to_port                  = "${var.weblogic_domain_ports["interface_managed"]}"
   source_security_group_id = "${aws_security_group.weblogic_interface_managed_elb.id}"
+  description              = "ELB in"
+}
+
+resource "aws_security_group_rule" "interface_managed_egress_1521" {
+  security_group_id        = "${aws_security_group.weblogic_interface_managed.id}"
+  type                     = "egress"
+  protocol                 = "tcp"
+  from_port                = 1521
+  to_port                  = 1521
+  source_security_group_id = "${aws_security_group.delius_db_in.id}"
+  description              = "Delius db out"
 }

--- a/security-groups/weblogic-ndelius.tf
+++ b/security-groups/weblogic-ndelius.tf
@@ -1,5 +1,8 @@
 # weblogic-ndelius.tf
 
+################################################################################
+## weblogic_ndelius_managed_elb
+################################################################################
 resource "aws_security_group" "weblogic_ndelius_managed_elb" {
   name        = "${var.environment_name}-weblogic-ndelius-managed-elb"
   vpc_id      = "${data.terraform_remote_state.vpc.vpc_id}"
@@ -17,15 +20,19 @@ output "sg_weblogic_ndelius_managed_elb_id" {
 
 #Allow users into the managed boxes on the useful port
 #TODO: Do we build a list of allowed source in or?
-resource "aws_security_group_rule" "wnme_managed_elb_in" {
+resource "aws_security_group_rule" "ndelius_managed_elb_ingress" {
   security_group_id = "${aws_security_group.weblogic_ndelius_managed_elb.id}"
   type              = "ingress"
   protocol          = "tcp"
   from_port         = "${var.weblogic_domain_ports["ndelius_managed"]}"
   to_port           = "${var.weblogic_domain_ports["ndelius_managed"]}"
   cidr_blocks       = ["0.0.0.0/0"]
+  description       = "World in"
 }
 
+################################################################################
+## weblogic_ndelius_admin_elb
+################################################################################
 resource "aws_security_group" "weblogic_ndelius_admin_elb" {
   name        = "${var.environment_name}-weblogic-ndelius-admin-elb"
   vpc_id      = "${data.terraform_remote_state.vpc.vpc_id}"
@@ -42,15 +49,19 @@ output "sg_weblogic_ndelius_admin_elb_id" {
 }
 
 #Allow admins into the admin box
-resource "aws_security_group_rule" "wnae_admin_elb_in" {
+resource "aws_security_group_rule" "ndelius_admin_elb_ingress" {
   security_group_id = "${aws_security_group.weblogic_ndelius_admin_elb.id}"
   type              = "ingress"
   protocol          = "tcp"
   from_port         = "${var.weblogic_domain_ports["ndelius_admin"]}"
   to_port           = "${var.weblogic_domain_ports["ndelius_admin"]}"
   cidr_blocks       = ["${values(data.terraform_remote_state.vpc.bastion_vpc_public_cidr)}"]
+  description       = "Admins in via bastion"
 }
 
+################################################################################
+## weblogic_ndelius_admin
+################################################################################
 resource "aws_security_group" "weblogic_ndelius_admin" {
   name        = "${var.environment_name}-weblogic-ndelius-admin"
   vpc_id      = "${data.terraform_remote_state.vpc.vpc_id}"
@@ -67,15 +78,55 @@ output "sg_weblogic_ndelius_admin_id" {
 }
 
 #Allow the ELB into the Admin port
-resource "aws_security_group_rule" "wnae_admin_elb" {
+resource "aws_security_group_rule" "ndelius_admin_elb_ingress_elb" {
   security_group_id        = "${aws_security_group.weblogic_ndelius_admin.id}"
   type                     = "ingress"
   protocol                 = "tcp"
   from_port                = "${var.weblogic_domain_ports["ndelius_admin"]}"
   to_port                  = "${var.weblogic_domain_ports["ndelius_admin"]}"
   source_security_group_id = "${aws_security_group.weblogic_ndelius_admin_elb.id}"
+  description              = "Admins via ELB in"
 }
 
+resource "aws_security_group_rule" "ndelius_admin_egress_1521" {
+  security_group_id        = "${aws_security_group.weblogic_ndelius_admin.id}"
+  type                     = "egress"
+  protocol                 = "tcp"
+  from_port                = 1521
+  to_port                  = 1521
+  source_security_group_id = "${aws_security_group.delius_db_in.id}"
+  description              = "Delius db"
+}
+
+# This is a temp solution to enable quick access to yum repos from dev env
+# during discovery.
+resource "aws_security_group_rule" "ndelius_admin_egress_80" {
+  count             = "${var.egress_80}"
+  security_group_id = "${aws_security_group.weblogic_ndelius_admin.id}"
+  type              = "egress"
+  protocol          = "tcp"
+  from_port         = 80
+  to_port           = 80
+  cidr_blocks       = ["0.0.0.0/0"]
+  description       = "yum repos"
+}
+
+# This is a temp solution to enable quick access to S3 bucket from dev env
+# during discovery.
+resource "aws_security_group_rule" "ndelius_admin_egress_443" {
+  count             = "${var.egress_443}"
+  security_group_id = "${aws_security_group.weblogic_ndelius_admin.id}"
+  type              = "egress"
+  protocol          = "tcp"
+  from_port         = 443
+  to_port           = 443
+  cidr_blocks       = ["0.0.0.0/0"]
+  description       = "s3"
+}
+
+################################################################################
+## weblogic_ndelius_managed
+################################################################################
 resource "aws_security_group" "weblogic_ndelius_managed" {
   name        = "${var.environment_name}-weblogic-ndelius-managed"
   vpc_id      = "${data.terraform_remote_state.vpc.vpc_id}"
@@ -92,11 +143,48 @@ output "sg_weblogic_ndelius_managed_id" {
 }
 
 #Allow the ELB into the managed port
-resource "aws_security_group_rule" "ndelius_elb" {
+resource "aws_security_group_rule" "ndelius_managed_ingress_elb" {
   security_group_id        = "${aws_security_group.weblogic_ndelius_managed.id}"
   type                     = "ingress"
   protocol                 = "tcp"
   from_port                = "${var.weblogic_domain_ports["ndelius_managed"]}"
   to_port                  = "${var.weblogic_domain_ports["ndelius_managed"]}"
   source_security_group_id = "${aws_security_group.weblogic_ndelius_managed_elb.id}"
+  description              = "ELB in"
+}
+
+resource "aws_security_group_rule" "ndelius_managed_egress_1521" {
+  security_group_id        = "${aws_security_group.weblogic_ndelius_managed.id}"
+  type                     = "egress"
+  protocol                 = "tcp"
+  from_port                = 1521
+  to_port                  = 1521
+  source_security_group_id = "${aws_security_group.delius_db_in.id}"
+  description              = "Delius db"
+}
+
+# This is a temp solution to enable quick access to yum repos from dev env
+# during discovery.
+resource "aws_security_group_rule" "ndelius_managed_egress_80" {
+  count             = "${var.egress_80}"
+  security_group_id = "${aws_security_group.weblogic_ndelius_managed.id}"
+  type              = "egress"
+  protocol          = "tcp"
+  from_port         = 80
+  to_port           = 80
+  cidr_blocks       = ["0.0.0.0/0"]
+  description       = "yum repos"
+}
+
+# This is a temp solution to enable quick access to S3 bucket from dev env
+# during discovery.
+resource "aws_security_group_rule" "ndelius_managed_egress_443" {
+  count             = "${var.egress_443}"
+  security_group_id = "${aws_security_group.weblogic_ndelius_managed.id}"
+  type              = "egress"
+  protocol          = "tcp"
+  from_port         = 443
+  to_port           = 443
+  cidr_blocks       = ["0.0.0.0/0"]
+  description       = "s3"
 }

--- a/security-groups/weblogic-ndelius.tf
+++ b/security-groups/weblogic-ndelius.tf
@@ -163,6 +163,16 @@ resource "aws_security_group_rule" "ndelius_managed_egress_1521" {
   description              = "Delius db"
 }
 
+resource "aws_security_group_rule" "ndelius_managed_egress_oid_ldap" {
+  security_group_id        = "${aws_security_group.weblogic_ndelius_managed.id}"
+  type                     = "egress"
+  protocol                 = "tcp"
+  from_port                = "${var.weblogic_domain_ports["oid_ldap"]}"
+  to_port                  = "${var.weblogic_domain_ports["oid_ldap"]}"
+  source_security_group_id = "${aws_security_group.weblogic_oid_managed_elb.id}"
+  description              = "OID LDAP out"
+}
+
 # This is a temp solution to enable quick access to yum repos from dev env
 # during discovery.
 resource "aws_security_group_rule" "ndelius_managed_egress_80" {

--- a/security-groups/weblogic-spg.tf
+++ b/security-groups/weblogic-spg.tf
@@ -163,6 +163,16 @@ resource "aws_security_group_rule" "spg_managed_egress_1521" {
   description              = "Delius db"
 }
 
+resource "aws_security_group_rule" "spg_managed_egress_oid_ldap" {
+  security_group_id        = "${aws_security_group.weblogic_spg_managed.id}"
+  type                     = "egress"
+  protocol                 = "tcp"
+  from_port                = "${var.weblogic_domain_ports["oid_ldap"]}"
+  to_port                  = "${var.weblogic_domain_ports["oid_ldap"]}"
+  source_security_group_id = "${aws_security_group.weblogic_oid_managed_elb.id}"
+  description              = "OID LDAP out"
+}
+
 # This is a temp solution to enable quick access to yum repos from dev env
 # during discovery.
 resource "aws_security_group_rule" "spg_managed_egress_80" {

--- a/security-groups/weblogic-spg.tf
+++ b/security-groups/weblogic-spg.tf
@@ -1,5 +1,8 @@
 # weblogic-spg.tf
 
+################################################################################
+## weblogic-spg-managed-elb
+################################################################################
 resource "aws_security_group" "weblogic_spg_managed_elb" {
   name        = "${var.environment_name}-weblogic-spg-managed-elb"
   vpc_id      = "${data.terraform_remote_state.vpc.vpc_id}"
@@ -17,15 +20,19 @@ output "sg_weblogic_spg_managed_elb_id" {
 
 #Allow users into the managed boxes on the useful port
 #TODO: Do we build a list of allowed source in or?
-resource "aws_security_group_rule" "wsme_managed_elb_in" {
+resource "aws_security_group_rule" "spg_managed_elb_ingress" {
   security_group_id = "${aws_security_group.weblogic_spg_managed_elb.id}"
   type              = "ingress"
   protocol          = "tcp"
   from_port         = "${var.weblogic_domain_ports["spg_managed"]}"
   to_port           = "${var.weblogic_domain_ports["spg_managed"]}"
   cidr_blocks       = ["0.0.0.0/0"]
+  description       = "world in"
 }
 
+################################################################################
+## weblogic-spg-admin-elb
+################################################################################
 resource "aws_security_group" "weblogic_spg_admin_elb" {
   name        = "${var.environment_name}-weblogic-spg-admin-elb"
   vpc_id      = "${data.terraform_remote_state.vpc.vpc_id}"
@@ -42,15 +49,19 @@ output "sg_weblogic_spg_admin_elb_id" {
 }
 
 #Allow admins into the admin box
-resource "aws_security_group_rule" "wsae_admin_elb_in" {
+resource "aws_security_group_rule" "spg_admin_elb_ingress" {
   security_group_id = "${aws_security_group.weblogic_spg_admin_elb.id}"
   type              = "ingress"
   protocol          = "tcp"
   from_port         = "${var.weblogic_domain_ports["spg_admin"]}"
   to_port           = "${var.weblogic_domain_ports["spg_admin"]}"
   cidr_blocks       = ["${values(data.terraform_remote_state.vpc.bastion_vpc_public_cidr)}"]
+  description       = "admins in via bastion"
 }
 
+################################################################################
+## weblogic-spg-admin
+################################################################################
 resource "aws_security_group" "weblogic_spg_admin" {
   name        = "${var.environment_name}-weblogic-spg-admin"
   vpc_id      = "${data.terraform_remote_state.vpc.vpc_id}"
@@ -67,13 +78,24 @@ output "sg_weblogic_spg_admin_id" {
 }
 
 #Allow the ELB into the Admin port
-resource "aws_security_group_rule" "wsae_admin_elb" {
+resource "aws_security_group_rule" "spg_admin_ingress_elb" {
   security_group_id        = "${aws_security_group.weblogic_spg_admin.id}"
   type                     = "ingress"
   protocol                 = "tcp"
   from_port                = "${var.weblogic_domain_ports["spg_admin"]}"
   to_port                  = "${var.weblogic_domain_ports["spg_admin"]}"
   source_security_group_id = "${aws_security_group.weblogic_spg_admin_elb.id}"
+  description              = "Admins via ELB in"
+}
+
+resource "aws_security_group_rule" "spg_admin_egress_1521" {
+  security_group_id        = "${aws_security_group.weblogic_spg_admin.id}"
+  type                     = "egress"
+  protocol                 = "tcp"
+  from_port                = 1521
+  to_port                  = 1521
+  source_security_group_id = "${aws_security_group.delius_db_in.id}"
+  description              = "delius db"
 }
 
 # This is a temp solution to enable quick access to yum repos from dev env
@@ -102,6 +124,9 @@ resource "aws_security_group_rule" "spg_admin_egress_443" {
   description       = "s3"
 }
 
+################################################################################
+## weblogic-spg-managed
+################################################################################
 resource "aws_security_group" "weblogic_spg_managed" {
   name        = "${var.environment_name}-weblogic-spg-managed"
   vpc_id      = "${data.terraform_remote_state.vpc.vpc_id}"
@@ -118,18 +143,29 @@ output "sg_weblogic_spg_managed_id" {
 }
 
 #Allow the ELB into the managed port
-resource "aws_security_group_rule" "spg_elb" {
+resource "aws_security_group_rule" "spg_managed_ingress_elb" {
   security_group_id        = "${aws_security_group.weblogic_spg_managed.id}"
   type                     = "ingress"
   protocol                 = "tcp"
   from_port                = "${var.weblogic_domain_ports["spg_managed"]}"
   to_port                  = "${var.weblogic_domain_ports["spg_managed"]}"
   source_security_group_id = "${aws_security_group.weblogic_spg_managed_elb.id}"
+  description              = "ELB in"
+}
+
+resource "aws_security_group_rule" "spg_managed_egress_1521" {
+  security_group_id        = "${aws_security_group.weblogic_spg_managed.id}"
+  type                     = "egress"
+  protocol                 = "tcp"
+  from_port                = 1521
+  to_port                  = 1521
+  source_security_group_id = "${aws_security_group.delius_db_in.id}"
+  description              = "delius db"
 }
 
 # This is a temp solution to enable quick access to yum repos from dev env
 # during discovery.
-resource "aws_security_group_rule" "spg_egress_80" {
+resource "aws_security_group_rule" "spg_managed_egress_80" {
   count             = "${var.egress_80}"
   security_group_id = "${aws_security_group.weblogic_spg_managed.id}"
   type              = "egress"
@@ -142,7 +178,7 @@ resource "aws_security_group_rule" "spg_egress_80" {
 
 # This is a temp solution to enable quick access to S3 bucket from dev env
 # during discovery.
-resource "aws_security_group_rule" "spg_egress_443" {
+resource "aws_security_group_rule" "spg_managed_egress_443" {
   count             = "${var.egress_443}"
   security_group_id = "${aws_security_group.weblogic_spg_managed.id}"
   type              = "egress"

--- a/security-groups/weblogic-spg.tf
+++ b/security-groups/weblogic-spg.tf
@@ -27,7 +27,7 @@ resource "aws_security_group_rule" "spg_managed_elb_ingress" {
   from_port         = "${var.weblogic_domain_ports["spg_managed"]}"
   to_port           = "${var.weblogic_domain_ports["spg_managed"]}"
   cidr_blocks       = ["0.0.0.0/0"]
-  description       = "world in"
+  description       = "World in"
 }
 
 ################################################################################

--- a/security-groups/weblogic-spg.tf
+++ b/security-groups/weblogic-spg.tf
@@ -56,7 +56,7 @@ resource "aws_security_group_rule" "spg_admin_elb_ingress" {
   from_port         = "${var.weblogic_domain_ports["spg_admin"]}"
   to_port           = "${var.weblogic_domain_ports["spg_admin"]}"
   cidr_blocks       = ["${values(data.terraform_remote_state.vpc.bastion_vpc_public_cidr)}"]
-  description       = "admins in via bastion"
+  description       = "Admins in via bastion"
 }
 
 ################################################################################
@@ -95,7 +95,7 @@ resource "aws_security_group_rule" "spg_admin_egress_1521" {
   from_port                = 1521
   to_port                  = 1521
   source_security_group_id = "${aws_security_group.delius_db_in.id}"
-  description              = "delius db"
+  description              = "Delius db"
 }
 
 # This is a temp solution to enable quick access to yum repos from dev env
@@ -160,7 +160,7 @@ resource "aws_security_group_rule" "spg_managed_egress_1521" {
   from_port                = 1521
   to_port                  = 1521
   source_security_group_id = "${aws_security_group.delius_db_in.id}"
-  description              = "delius db"
+  description              = "Delius db"
 }
 
 # This is a temp solution to enable quick access to yum repos from dev env


### PR DESCRIPTION
Chosen to keep security groups for the Weblogic servers in a single file but have made easier to read with code comment blocks.
All rules now have descriptions.
Weblogic servers now have egress rules for access to the DB and OID LDAP where appropriate and match the corresponding ingress rule.
NOTE: rules and groups will need further refactor if/when admin servers perform role of managed servers.