### PR TITLE
Fix for is-production tag set as zero (0) in AWS.

### DIFF
--- a/application/interface/variables.tf
+++ b/application/interface/variables.tf
@@ -61,3 +61,7 @@ variable "ldap_ports" {
   type        = "map"
   description = "Map of the ports that the ldap ports"
 }
+
+variable "tags" {
+  type = "map"
+}

--- a/application/interface/weblogic-interface.tf
+++ b/application/interface/weblogic-interface.tf
@@ -28,7 +28,7 @@ module "interface" {
     data.terraform_remote_state.vpc.vpc_private-subnet-az3,
   )}"
 
-  tags                         = "${data.terraform_remote_state.vpc.tags}"
+  tags                         = "${var.tags}"
   environment_name             = "${data.terraform_remote_state.vpc.environment_name}"
   bastion_inventory            = "${data.terraform_remote_state.vpc.bastion_inventory}"
   environment_identifier       = "${var.environment_identifier}"

--- a/application/ldap/apacheds-ldap.tf
+++ b/application/ldap/apacheds-ldap.tf
@@ -26,7 +26,7 @@ module "oid" {
     data.terraform_remote_state.vpc.vpc_private-subnet-az3,
   )}"
 
-  tags                         = "${data.terraform_remote_state.vpc.tags}"
+  tags                         = "${var.tags}"
   environment_name             = "${data.terraform_remote_state.vpc.environment_name}"
   bastion_inventory            = "${data.terraform_remote_state.vpc.bastion_inventory}"
   environment_identifier       = "${var.environment_identifier}"

--- a/application/ldap/variables.tf
+++ b/application/ldap/variables.tf
@@ -51,3 +51,7 @@ variable "ansible_vars_apacheds" {
   description = "Ansible vars for user_data script"
   type        = "map"
 }
+
+variable "tags" {
+  type = "map"
+}

--- a/application/ndelius/variables.tf
+++ b/application/ndelius/variables.tf
@@ -61,3 +61,7 @@ variable "ldap_ports" {
   type        = "map"
   description = "Map of the ports that the ldap ports"
 }
+
+variable "tags" {
+  type = "map"
+}

--- a/application/ndelius/weblogic-ndelius.tf
+++ b/application/ndelius/weblogic-ndelius.tf
@@ -28,7 +28,7 @@ module "ndelius" {
     data.terraform_remote_state.vpc.vpc_private-subnet-az3,
   )}"
 
-  tags                         = "${data.terraform_remote_state.vpc.tags}"
+  tags                         = "${var.tags}"
   environment_name             = "${data.terraform_remote_state.vpc.environment_name}"
   bastion_inventory            = "${data.terraform_remote_state.vpc.bastion_inventory}"
   environment_identifier       = "${var.environment_identifier}"

--- a/application/spg/variables.tf
+++ b/application/spg/variables.tf
@@ -61,3 +61,7 @@ variable "ldap_ports" {
   type        = "map"
   description = "Map of the ports that the ldap ports"
 }
+
+variable "tags" {
+  type = "map"
+}

--- a/application/spg/weblogic-spg.tf
+++ b/application/spg/weblogic-spg.tf
@@ -28,7 +28,7 @@ module "spg" {
     data.terraform_remote_state.vpc.vpc_private-subnet-az3,
   )}"
 
-  tags                         = "${data.terraform_remote_state.vpc.tags}"
+  tags                         = "${var.tags}"
   environment_name             = "${data.terraform_remote_state.vpc.environment_name}"
   bastion_inventory            = "${data.terraform_remote_state.vpc.bastion_inventory}"
   environment_identifier       = "${var.environment_identifier}"

--- a/database/server-delius-db.tf
+++ b/database/server-delius-db.tf
@@ -15,7 +15,7 @@ module "delius_db" {
     "${data.terraform_remote_state.delius_core_security_groups.sg_common_out_id}",
   ]
 
-  tags                         = "${data.terraform_remote_state.vpc.tags}"
+  tags                         = "${var.tags}"
   environment_name             = "${data.terraform_remote_state.vpc.environment_name}"
   bastion_inventory            = "${data.terraform_remote_state.vpc.bastion_inventory}"
   environment_identifier       = "${var.environment_identifier}"

--- a/database/variables.tf
+++ b/database/variables.tf
@@ -42,3 +42,7 @@ variable "ansible_vars_oracle_db" {
   description = "Ansible (oracle_db) vars for user_data script "
   type        = "map"
 }
+
+variable "tags" {
+  type = "map"
+}

--- a/key_profile/kms_keys.tf
+++ b/key_profile/kms_keys.tf
@@ -1,7 +1,7 @@
 module "kms_key_app" {
   source   = "../modules/keys/encryption_key"
   key_name = "${var.environment_name}-app"
-  tags     = "${merge(data.terraform_remote_state.vpc.tags, map("Name", "${var.environment_name}-app"))}"
+  tags     = "${merge(var.tags, map("Name", "${var.environment_name}-app"))}"
 }
 
 output "kms_arn_app" {

--- a/key_profile/variables.tf
+++ b/key_profile/variables.tf
@@ -17,3 +17,7 @@ variable "short_environment_name" {
 variable "dependencies_bucket_arn" {
   description = "The S3 bucket arn for software and application dependencies"
 }
+
+variable "tags" {
+  type = "map"
+}

--- a/security-groups/apacheds-ldap.tf
+++ b/security-groups/apacheds-ldap.tf
@@ -7,7 +7,7 @@ resource "aws_security_group" "apacheds_ldap_public_elb" {
   name        = "${var.environment_name}-apacheds-ldap-public-elb"
   vpc_id      = "${data.terraform_remote_state.vpc.vpc_id}"
   description = "Apache DS LDAP Public ELB"
-  tags        = "${merge(data.terraform_remote_state.vpc.tags, map("Name", "${var.environment_name}-apacheds-ldap-public-elb", "Type", "Public"))}"
+  tags        = "${merge(var.tags, map("Name", "${var.environment_name}-apacheds-ldap-public-elb", "Type", "Public"))}"
 
   lifecycle {
     create_before_destroy = true
@@ -25,7 +25,7 @@ resource "aws_security_group" "apacheds_ldap_private_elb" {
   name        = "${var.environment_name}-apacheds-ldap-private-elb"
   vpc_id      = "${data.terraform_remote_state.vpc.vpc_id}"
   description = "Weblogic oid admin server"
-  tags        = "${merge(data.terraform_remote_state.vpc.tags, map("Name", "${var.environment_name}-apacheds-ldap-private-elb", "Type", "Private"))}"
+  tags        = "${merge(var.tags, map("Name", "${var.environment_name}-apacheds-ldap-private-elb", "Type", "Private"))}"
 
   lifecycle {
     create_before_destroy = true
@@ -87,7 +87,7 @@ resource "aws_security_group" "apacheds_ldap" {
   name        = "${var.environment_name}-apacheds-ldap"
   vpc_id      = "${data.terraform_remote_state.vpc.vpc_id}"
   description = "ApacheDS LDAP server"
-  tags        = "${merge(data.terraform_remote_state.vpc.tags, map("Name", "${var.environment_name}-apacheds-ldap", "Type", "Private"))}"
+  tags        = "${merge(var.tags, map("Name", "${var.environment_name}-apacheds-ldap", "Type", "Private"))}"
 
   lifecycle {
     create_before_destroy = true

--- a/security-groups/common-out.tf
+++ b/security-groups/common-out.tf
@@ -7,7 +7,7 @@ resource "aws_security_group" "common_out" {
   name        = "${var.environment_name}-common-out"
   vpc_id      = "${data.terraform_remote_state.vpc.vpc_id}"
   description = "Common egress rules"
-  tags        = "${merge(data.terraform_remote_state.vpc.tags, map("Name", "${var.environment_name}-common-out", "Type", "COMMON"))}"
+  tags        = "${merge(var.tags, map("Name", "${var.environment_name}-common-out", "Type", "COMMON"))}"
 
   lifecycle {
     create_before_destroy = true

--- a/security-groups/delius-db-in.tf
+++ b/security-groups/delius-db-in.tf
@@ -7,7 +7,7 @@ resource "aws_security_group" "delius_db_in" {
   name        = "${var.environment_name}-delius-db-in"
   vpc_id      = "${data.terraform_remote_state.vpc.vpc_id}"
   description = "Delius database in"
-  tags        = "${merge(data.terraform_remote_state.vpc.tags, map("Name", "${var.environment_name}-delius-db-in", "Type", "DB"))}"
+  tags        = "${merge(var.tags, map("Name", "${var.environment_name}-delius-db-in", "Type", "DB"))}"
 
   lifecycle {
     create_before_destroy = true

--- a/security-groups/delius-db-out.tf
+++ b/security-groups/delius-db-out.tf
@@ -7,7 +7,7 @@ resource "aws_security_group" "delius_db_out" {
   name        = "${var.environment_name}-delius-db-out"
   vpc_id      = "${data.terraform_remote_state.vpc.vpc_id}"
   description = "Delius database out"
-  tags        = "${merge(data.terraform_remote_state.vpc.tags, map("Name", "${var.environment_name}-delius-db-out", "Type", "DB"))}"
+  tags        = "${merge(var.tags, map("Name", "${var.environment_name}-delius-db-out", "Type", "DB"))}"
 
   lifecycle {
     create_before_destroy = true

--- a/security-groups/oid-db-in.tf
+++ b/security-groups/oid-db-in.tf
@@ -7,7 +7,7 @@ resource "aws_security_group" "oid_db_in" {
   name        = "${var.environment_name}-oid-db-in"
   vpc_id      = "${data.terraform_remote_state.vpc.vpc_id}"
   description = "OID database in"
-  tags        = "${merge(data.terraform_remote_state.vpc.tags, map("Name", "${var.environment_name}-oid-db-in", "Type", "DB"))}"
+  tags        = "${merge(var.tags, map("Name", "${var.environment_name}-oid-db-in", "Type", "DB"))}"
 
   lifecycle {
     create_before_destroy = true

--- a/security-groups/oid-db-out.tf
+++ b/security-groups/oid-db-out.tf
@@ -7,7 +7,7 @@ resource "aws_security_group" "oid_db_out" {
   name        = "${var.environment_name}-oid-db-out"
   vpc_id      = "${data.terraform_remote_state.vpc.vpc_id}"
   description = "OID Database out"
-  tags        = "${merge(data.terraform_remote_state.vpc.tags, map("Name", "${var.environment_name}-oid-db-out", "Type", "DB"))}"
+  tags        = "${merge(var.tags, map("Name", "${var.environment_name}-oid-db-out", "Type", "DB"))}"
 
   lifecycle {
     create_before_destroy = true

--- a/security-groups/variables.tf
+++ b/security-groups/variables.tf
@@ -48,3 +48,7 @@ variable "user_access_cidr_blocks" {
   description = "CIDRS for access via public/user network"
   type        = "list"
 }
+
+variable "tags" {
+  type = "map"
+}

--- a/security-groups/weblogic-interface.tf
+++ b/security-groups/weblogic-interface.tf
@@ -7,7 +7,7 @@ resource "aws_security_group" "weblogic_interface_managed_elb" {
   name        = "${var.environment_name}-weblogic-interface-managed-elb"
   vpc_id      = "${data.terraform_remote_state.vpc.vpc_id}"
   description = "Weblogic interface admin server"
-  tags        = "${merge(data.terraform_remote_state.vpc.tags, map("Name", "${var.environment_name}-weblogic-interface-managed-elb", "Type", "Private"))}"
+  tags        = "${merge(var.tags, map("Name", "${var.environment_name}-weblogic-interface-managed-elb", "Type", "Private"))}"
 
   lifecycle {
     create_before_destroy = true
@@ -47,7 +47,7 @@ resource "aws_security_group" "weblogic_interface_admin_elb" {
   name        = "${var.environment_name}-weblogic-interface-admin-elb"
   vpc_id      = "${data.terraform_remote_state.vpc.vpc_id}"
   description = "Weblogic interface admin server"
-  tags        = "${merge(data.terraform_remote_state.vpc.tags, map("Name", "${var.environment_name}-weblogic-interface-admin-elb", "Type", "Private"))}"
+  tags        = "${merge(var.tags, map("Name", "${var.environment_name}-weblogic-interface-admin-elb", "Type", "Private"))}"
 
   lifecycle {
     create_before_destroy = true
@@ -86,7 +86,7 @@ resource "aws_security_group" "weblogic_interface_admin" {
   name        = "${var.environment_name}-weblogic-interface-admin"
   vpc_id      = "${data.terraform_remote_state.vpc.vpc_id}"
   description = "Weblogic interface admin server"
-  tags        = "${merge(data.terraform_remote_state.vpc.tags, map("Name", "${var.environment_name}-weblogic-interface-admin", "Type", "Private"))}"
+  tags        = "${merge(var.tags, map("Name", "${var.environment_name}-weblogic-interface-admin", "Type", "Private"))}"
 
   lifecycle {
     create_before_destroy = true
@@ -135,7 +135,7 @@ resource "aws_security_group" "weblogic_interface_managed" {
   name        = "${var.environment_name}-weblogic-interface-managed"
   vpc_id      = "${data.terraform_remote_state.vpc.vpc_id}"
   description = "Weblogic interface managed servers"
-  tags        = "${merge(data.terraform_remote_state.vpc.tags, map("Name", "${var.environment_name}-weblogic-interface-managed", "Type", "Private"))}"
+  tags        = "${merge(var.tags, map("Name", "${var.environment_name}-weblogic-interface-managed", "Type", "Private"))}"
 
   lifecycle {
     create_before_destroy = true

--- a/security-groups/weblogic-ndelius.tf
+++ b/security-groups/weblogic-ndelius.tf
@@ -7,7 +7,7 @@ resource "aws_security_group" "weblogic_ndelius_managed_elb" {
   name        = "${var.environment_name}-weblogic-ndelius-managed-elb"
   vpc_id      = "${data.terraform_remote_state.vpc.vpc_id}"
   description = "Weblogic ndelius admin server"
-  tags        = "${merge(data.terraform_remote_state.vpc.tags, map("Name", "${var.environment_name}-weblogic-ndelius-managed-elb", "Type", "Private"))}"
+  tags        = "${merge(var.tags, map("Name", "${var.environment_name}-weblogic-ndelius-managed-elb", "Type", "Private"))}"
 
   lifecycle {
     create_before_destroy = true
@@ -47,7 +47,7 @@ resource "aws_security_group" "weblogic_ndelius_admin_elb" {
   name        = "${var.environment_name}-weblogic-ndelius-admin-elb"
   vpc_id      = "${data.terraform_remote_state.vpc.vpc_id}"
   description = "Weblogic ndelius admin server"
-  tags        = "${merge(data.terraform_remote_state.vpc.tags, map("Name", "${var.environment_name}-weblogic-ndelius-admin-elb", "Type", "Private"))}"
+  tags        = "${merge(var.tags, map("Name", "${var.environment_name}-weblogic-ndelius-admin-elb", "Type", "Private"))}"
 
   lifecycle {
     create_before_destroy = true
@@ -86,7 +86,7 @@ resource "aws_security_group" "weblogic_ndelius_admin" {
   name        = "${var.environment_name}-weblogic-ndelius-admin"
   vpc_id      = "${data.terraform_remote_state.vpc.vpc_id}"
   description = "Weblogic ndelius admin server"
-  tags        = "${merge(data.terraform_remote_state.vpc.tags, map("Name", "${var.environment_name}-weblogic-ndelius-admin", "Type", "Private"))}"
+  tags        = "${merge(var.tags, map("Name", "${var.environment_name}-weblogic-ndelius-admin", "Type", "Private"))}"
 
   lifecycle {
     create_before_destroy = true
@@ -125,7 +125,7 @@ resource "aws_security_group" "weblogic_ndelius_managed" {
   name        = "${var.environment_name}-weblogic-ndelius-managed"
   vpc_id      = "${data.terraform_remote_state.vpc.vpc_id}"
   description = "Weblogic ndelius managed servers"
-  tags        = "${merge(data.terraform_remote_state.vpc.tags, map("Name", "${var.environment_name}-weblogic-ndelius-managed", "Type", "Private"))}"
+  tags        = "${merge(var.tags, map("Name", "${var.environment_name}-weblogic-ndelius-managed", "Type", "Private"))}"
 
   lifecycle {
     create_before_destroy = true

--- a/security-groups/weblogic-oid.tf
+++ b/security-groups/weblogic-oid.tf
@@ -7,7 +7,7 @@ resource "aws_security_group" "weblogic_oid_managed_elb" {
   name        = "${var.environment_name}-weblogic-oid-managed-elb"
   vpc_id      = "${data.terraform_remote_state.vpc.vpc_id}"
   description = "Weblogic oid admin server"
-  tags        = "${merge(data.terraform_remote_state.vpc.tags, map("Name", "${var.environment_name}-weblogic-oid-managed-elb", "Type", "Private"))}"
+  tags        = "${merge(var.tags, map("Name", "${var.environment_name}-weblogic-oid-managed-elb", "Type", "Private"))}"
 
   lifecycle {
     create_before_destroy = true
@@ -57,7 +57,7 @@ resource "aws_security_group" "weblogic_oid_admin_elb" {
   name        = "${var.environment_name}-weblogic-oid-admin-elb"
   vpc_id      = "${data.terraform_remote_state.vpc.vpc_id}"
   description = "Weblogic oid admin server"
-  tags        = "${merge(data.terraform_remote_state.vpc.tags, map("Name", "${var.environment_name}-weblogic-oid-admin-elb", "Type", "Private"))}"
+  tags        = "${merge(var.tags, map("Name", "${var.environment_name}-weblogic-oid-admin-elb", "Type", "Private"))}"
 
   lifecycle {
     create_before_destroy = true
@@ -97,7 +97,7 @@ resource "aws_security_group" "weblogic_oid_admin" {
   name        = "${var.environment_name}-weblogic-oid-admin"
   vpc_id      = "${data.terraform_remote_state.vpc.vpc_id}"
   description = "Weblogic oid admin server"
-  tags        = "${merge(data.terraform_remote_state.vpc.tags, map("Name", "${var.environment_name}-weblogic-oid-admin", "Type", "Private"))}"
+  tags        = "${merge(var.tags, map("Name", "${var.environment_name}-weblogic-oid-admin", "Type", "Private"))}"
 
   lifecycle {
     create_before_destroy = true
@@ -145,7 +145,7 @@ resource "aws_security_group" "weblogic_oid_managed" {
   name        = "${var.environment_name}-weblogic-oid-managed"
   vpc_id      = "${data.terraform_remote_state.vpc.vpc_id}"
   description = "Weblogic oid managed servers"
-  tags        = "${merge(data.terraform_remote_state.vpc.tags, map("Name", "${var.environment_name}-weblogic-oid-managed", "Type", "Private"))}"
+  tags        = "${merge(var.tags, map("Name", "${var.environment_name}-weblogic-oid-managed", "Type", "Private"))}"
 
   lifecycle {
     create_before_destroy = true

--- a/security-groups/weblogic-spg.tf
+++ b/security-groups/weblogic-spg.tf
@@ -7,7 +7,7 @@ resource "aws_security_group" "weblogic_spg_managed_elb" {
   name        = "${var.environment_name}-weblogic-spg-managed-elb"
   vpc_id      = "${data.terraform_remote_state.vpc.vpc_id}"
   description = "Weblogic spg admin server"
-  tags        = "${merge(data.terraform_remote_state.vpc.tags, map("Name", "${var.environment_name}-weblogic-spg-managed-elb", "Type", "Private"))}"
+  tags        = "${merge(var.tags, map("Name", "${var.environment_name}-weblogic-spg-managed-elb", "Type", "Private"))}"
 
   lifecycle {
     create_before_destroy = true
@@ -37,7 +37,7 @@ resource "aws_security_group" "weblogic_spg_admin_elb" {
   name        = "${var.environment_name}-weblogic-spg-admin-elb"
   vpc_id      = "${data.terraform_remote_state.vpc.vpc_id}"
   description = "Weblogic spg admin server"
-  tags        = "${merge(data.terraform_remote_state.vpc.tags, map("Name", "${var.environment_name}-weblogic-spg-admin-elb", "Type", "Private"))}"
+  tags        = "${merge(var.tags, map("Name", "${var.environment_name}-weblogic-spg-admin-elb", "Type", "Private"))}"
 
   lifecycle {
     create_before_destroy = true
@@ -76,7 +76,7 @@ resource "aws_security_group" "weblogic_spg_admin" {
   name        = "${var.environment_name}-weblogic-spg-admin"
   vpc_id      = "${data.terraform_remote_state.vpc.vpc_id}"
   description = "Weblogic spg admin server"
-  tags        = "${merge(data.terraform_remote_state.vpc.tags, map("Name", "${var.environment_name}-weblogic-spg-admin", "Type", "Private"))}"
+  tags        = "${merge(var.tags, map("Name", "${var.environment_name}-weblogic-spg-admin", "Type", "Private"))}"
 
   lifecycle {
     create_before_destroy = true
@@ -125,7 +125,7 @@ resource "aws_security_group" "weblogic_spg_managed" {
   name        = "${var.environment_name}-weblogic-spg-managed"
   vpc_id      = "${data.terraform_remote_state.vpc.vpc_id}"
   description = "Weblogic spg managed servers"
-  tags        = "${merge(data.terraform_remote_state.vpc.tags, map("Name", "${var.environment_name}-weblogic-spg-managed", "Type", "Private"))}"
+  tags        = "${merge(var.tags, map("Name", "${var.environment_name}-weblogic-spg-managed", "Type", "Private"))}"
 
   lifecycle {
     create_before_destroy = true


### PR DESCRIPTION
Appears that when the tags output for this value is interpreted as a boolean rather than a string.