### PR TITLE
Use AWS resources instead of modules, to fix ASGs not being deleted correctly

### DIFF
--- a/modules/apacheds-ldap/asg_master.tf
+++ b/modules/apacheds-ldap/asg_master.tf
@@ -1,24 +1,41 @@
-module "master_launch_cfg" {
-  source                      = "git::https://github.com/ministryofjustice/hmpps-terraform-modules.git?ref=master//modules//launch_configuration//noblockdevice"
-  launch_configuration_name   = "${var.environment_name}-${var.tier_name}-master"
+resource "aws_launch_configuration" "master_launch_cfg" {
+  name_prefix                 = "${var.environment_name}-${var.tier_name}-master-launch-cfg-"
   image_id                    = "${var.ami_id}"
   instance_type               = "${var.instance_type}"
-  volume_size                 = 50
-  volume_type                 = "gp2"
-  instance_profile            = "${var.iam_instance_profile}"
+  iam_instance_profile        = "${var.iam_instance_profile}"
   key_name                    = "${var.key_name}"
   security_groups             = ["${var.security_groups}"]
+  associate_public_ip_address = "false"
   user_data                   = "${data.template_file.user_data.rendered}"
+  enable_monitoring           = "true"
+  ebs_optimized               = "false"
+
+  root_block_device {
+    volume_type = "gp2"
+    volume_size = 50
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
-module "master_asg" {
-  source                = "git::https://github.com/ministryofjustice/hmpps-terraform-modules.git?ref=pre-shared-vpc//modules//autoscaling//group//asg_classic_lb"
-  asg_name              = "${var.environment_name}-${var.tier_name}-master"
-  asg_min               = 1
-  asg_desired           = 1
-  asg_max               = 1
-  launch_configuration  = "${module.master_launch_cfg.launch_name}"
-  load_balancers        = ["${aws_elb.ldap_master_lb.id}"]
-  subnet_ids            = ["${var.private_subnets}"]
-  tags                  = "${merge(var.tags, map("Name", "${var.environment_name}-${var.tier_name}-master-asg"))}"
+resource "aws_autoscaling_group" "master_asg" {
+  name                 = "${var.environment_name}-${var.tier_name}-master"
+  vpc_zone_identifier  = ["${var.private_subnets}"]
+  min_size             = "1"
+  max_size             = "1"
+  desired_capacity     = "1"
+  launch_configuration = "${aws_launch_configuration.master_launch_cfg.id}"
+  load_balancers       = ["${aws_elb.ldap_master_lb.id}"]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = ["${data.null_data_source.tags.*.outputs}", {
+    key                 = "Name"
+    value               = "${var.environment_name}-${var.tier_name}-master-asg"
+    propagate_at_launch = true
+  }]
 }

--- a/modules/apacheds-ldap/asg_slaves.tf
+++ b/modules/apacheds-ldap/asg_slaves.tf
@@ -1,24 +1,41 @@
-module "slave_launch_cfg" {
-  source                      = "git::https://github.com/ministryofjustice/hmpps-terraform-modules.git?ref=master//modules//launch_configuration//noblockdevice"
-  launch_configuration_name   = "${var.environment_name}-${var.tier_name}-slave"
+resource "aws_launch_configuration" "slave_launch_cfg" {
+  name_prefix                 = "${var.environment_name}-${var.tier_name}-slave-launch-cfg-"
   image_id                    = "${var.ami_id}"
   instance_type               = "${var.instance_type}"
-  volume_size                 = 50
-  volume_type                 = "gp2"
-  instance_profile            = "${var.iam_instance_profile}"
+  iam_instance_profile        = "${var.iam_instance_profile}"
   key_name                    = "${var.key_name}"
   security_groups             = ["${var.security_groups}"]
+  associate_public_ip_address = "false"
   user_data                   = "${data.template_file.user_data_slave.rendered}"
+  enable_monitoring           = "true"
+  ebs_optimized               = "false"
+
+  root_block_device {
+    volume_type = "gp2"
+    volume_size = 50
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
-module "slave_asg" {
-  source                = "git::https://github.com/ministryofjustice/hmpps-terraform-modules.git?ref=pre-shared-vpc//modules//autoscaling//group//asg_classic_lb"
-  asg_name              = "${var.environment_name}-${var.tier_name}-slave"
-  asg_min               = 1
-  asg_desired           = 2
-  asg_max               = 10
-  launch_configuration  = "${module.slave_launch_cfg.launch_name}"
-  load_balancers        = ["${aws_elb.ldap_readonly_lb.id}"]
-  subnet_ids            = ["${var.private_subnets}"]
-  tags                  = "${merge(var.tags, map("Name", "${var.environment_name}-${var.tier_name}-slave-asg"))}"
+resource "aws_autoscaling_group" "slave_asg" {
+  name                 = "${var.environment_name}-${var.tier_name}-slave"
+  vpc_zone_identifier  = ["${var.private_subnets}"]
+  min_size             = "1"
+  max_size             = "10"
+  desired_capacity     = "2"
+  launch_configuration = "${aws_launch_configuration.slave_launch_cfg.id}"
+  load_balancers       = ["${aws_elb.ldap_readonly_lb.id}"]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = ["${data.null_data_source.tags.*.outputs}", {
+    key                 = "Name"
+    value               = "${var.environment_name}-${var.tier_name}-slave-asg"
+    propagate_at_launch = true
+  }]
 }

--- a/modules/apacheds-ldap/main.tf
+++ b/modules/apacheds-ldap/main.tf
@@ -75,3 +75,14 @@ data "template_file" "user_data_slave" {
     provider_host          = "${aws_route53_record.ldap_elb_private.fqdn}"
   }
 }
+
+# This null_data_source is required to convert our Map of tags, to the required List of tags for ASGs
+# see: https://github.com/hashicorp/terraform/issues/16980
+data "null_data_source" "tags" {
+  count = "${length(keys(var.tags))}"
+  inputs = {
+    key                 = "${element(keys(var.tags), count.index)}"
+    value               = "${element(values(var.tags), count.index)}"
+    propagate_at_launch = true
+  }
+}

--- a/modules/weblogic-admin-only/wls.tf
+++ b/modules/weblogic-admin-only/wls.tf
@@ -1,31 +1,59 @@
 # WebLogic auto-scaling group with fixed instance count
 
-module "wls_launch_cfg" {
-  source                      = "git::https://github.com/ministryofjustice/hmpps-terraform-modules.git?ref=master//modules//launch_configuration//noblockdevice"
-  launch_configuration_name   = "${var.environment_name}-${var.tier_name}"
+resource "aws_launch_configuration" "wls_launch_cfg" {
+  name_prefix                 = "${var.environment_name}-${var.tier_name}-launch-cfg-"
   image_id                    = "${var.ami_id}"
   instance_type               = "${var.instance_type}"
-  volume_size                 = 50
-  volume_type                 = "gp2"
-  instance_profile            = "${var.iam_instance_profile}"
+  iam_instance_profile        = "${var.iam_instance_profile}"
   key_name                    = "${var.key_name}"
   security_groups             = ["${var.security_groups}"]
+  associate_public_ip_address = "false"
   user_data                   = "${data.template_file.user_data.rendered}"
-}
+  enable_monitoring           = "true"
+  ebs_optimized               = "false"
 
-module "wls_asg" {
-  source                = "git::https://github.com/ministryofjustice/hmpps-terraform-modules.git?ref=pre-shared-vpc//modules//autoscaling//group//asg_classic_lb"
-  asg_name              = "${var.environment_name}-${var.tier_name}"
-  asg_min               = "${var.instance_count}"
-  asg_desired           = "${var.instance_count}"
-  asg_max               = "${var.instance_count}"
-  launch_configuration  = "${module.wls_launch_cfg.launch_name}"
-  load_balancers        = ["${aws_elb.internal.id}"]
-  subnet_ids            = ["${var.private_subnets}"]
-  tags                  = "${merge(var.tags, map("Name", "${var.environment_name}-${var.tier_name}-asg"))}"
+  root_block_device {
+    volume_type = "gp2"
+    volume_size = 50
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_autoscaling_attachment" "wls_asg_attachment" {
-  autoscaling_group_name = "${module.wls_asg.autoscale_id}"
+  autoscaling_group_name = "${aws_autoscaling_group.wls_asg.id}"
   alb_target_group_arn   = "${aws_lb_target_group.external_lb_target_group.arn}"
+}
+
+# This null_data_source is required to convert our Map of tags, to the required List of tags for ASGs
+# see: https://github.com/hashicorp/terraform/issues/16980
+data "null_data_source" "tags" {
+  count = "${length(keys(var.tags))}"
+  inputs = {
+    key                 = "${element(keys(var.tags), count.index)}"
+    value               = "${element(values(var.tags), count.index)}"
+    propagate_at_launch = true
+  }
+}
+
+resource "aws_autoscaling_group" "wls_asg" {
+  name                 = "${var.environment_name}-${var.tier_name}"
+  vpc_zone_identifier  = ["${var.private_subnets}"]
+  min_size             = "${var.instance_count}"
+  max_size             = "${var.instance_count}"
+  desired_capacity     = "${var.instance_count}"
+  launch_configuration = "${aws_launch_configuration.wls_launch_cfg.id}"
+  load_balancers       = ["${aws_elb.internal.id}"]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = ["${data.null_data_source.tags.*.outputs}", {
+    key                 = "Name"
+    value               = "${var.environment_name}-${var.tier_name}-asg"
+    propagate_at_launch = true
+  }]
 }


### PR DESCRIPTION
I know we were planning to change the module, but making this change to the module didn't fix the issue... It fixed straight away as soon as I stopped using the module altogether and used the resources directly. For the sake of fixing the pipeline, I think it's worthwhile sticking with this approach at least for now.