### PR TITLE
removed parameter from pipeline block as we don't supply and choices …

### DIFF
--- a/apply_dcore_tf_pipeline.Jenkinsfile
+++ b/apply_dcore_tf_pipeline.Jenkinsfile
@@ -2,6 +2,16 @@ def project = [:]
 project.config    = 'hmpps-env-configs'
 project.dcore     = 'hmpps-delius-core-terraform'
 
+// Parameters required for job
+// parameters:
+//     choice:
+//       name: 'environment_name'
+//       description: 'Environment name.'
+//     booleanParam:
+//       name: 'confirmation'
+//       description: 'Whether to require manual confirmation of terraform plans.'
+
+
 def prepare_env() {
     sh '''
     #!/usr/env/bin bash
@@ -116,13 +126,6 @@ def debug_env() {
 pipeline {
 
     agent { label "jenkins_slave" }
-
-    parameters {
-        choice(
-          name: 'environment_name',
-          description: 'Environment name.'
-        )
-    }
 
 
     stages {

--- a/check_infrastructure.Jenkinsfile
+++ b/check_infrastructure.Jenkinsfile
@@ -2,6 +2,15 @@ def project = [:]
 project.config    = 'hmpps-env-configs'
 project.dcore     = 'hmpps-delius-core-terraform'
 
+// Parameters required for job
+// parameters:
+//     choice:
+//       name: 'environment_name'
+//       description: 'Environment name.'
+//     booleanParam:
+//       name: 'confirmation'
+//       description: 'Whether to require manual confirmation of terraform plans.'
+
 def prepare_env() {
     sh '''
     #!/usr/env/bin bash
@@ -42,13 +51,6 @@ def plan_submodule(config_dir, env_name, git_project_dir, submodule_name) {
 pipeline {
 
     agent { label "jenkins_slave" }
-
-    parameters {
-        choice(
-          name: 'environment_name',
-          description: 'Environment name.'
-        )
-    }
 
     stages {
 


### PR DESCRIPTION
…in the file.

I guess we're using choice rather than string as the risk of changeing the environment name inadvertantly is reduced and only admins should be able to edit the job.
Added comment to show which two parameters are required.