### PR TITLE
Feature/dam 56 outputs

### DIFF
--- a/application/ndelius/weblogic-ndelius.tf
+++ b/application/ndelius/weblogic-ndelius.tf
@@ -158,3 +158,7 @@ output "private_fqdn_ndelius_external_nlb" {
 output "public_fqdn_ndelius_external_lb" {
   value = "${module.ndelius.public_fqdn_external_nlb}"
 }
+
+output "newtech_webfrontend_target_group_arn" {
+  value = "${module.ndelius.newtech_webfrontend_targetgroup_arn}"
+}

--- a/modules/weblogic-admin-only/internal_alb.tf
+++ b/modules/weblogic-admin-only/internal_alb.tf
@@ -149,3 +149,7 @@ output "private_fqdn_internal_alb" {
 output "public_fqdn_internal_alb" {
   value = "${aws_route53_record.internal_alb_public.fqdn}"
 }
+
+output "newtech_webfrontend_targetgroup_arn" {
+  value = "${aws_lb_target_group.newtechweb_target_group.arn}"
+}

--- a/modules/weblogic-admin-only/internal_alb.tf
+++ b/modules/weblogic-admin-only/internal_alb.tf
@@ -46,6 +46,8 @@ resource "aws_lb_target_group" "newtechweb_target_group" {
   protocol  = "HTTP"
   port      = "9000"
   tags      = "${merge(var.tags, map("Name", "${var.short_environment_name}-${var.tier_name}-newtechweb"))}"
+  # Targets will be ECS tasks running in awsvpc mode so type needs to be ip
+  target_type = "ip"
   health_check {
     protocol  = "HTTP"
     path      = "/healthcheck"


### PR DESCRIPTION
Updates newtech web target group type to be ip so it'll work with ecs tasks in awsvpc mode. Then adds the tg arn as an output for use by the ecs task itself.