### PR TITLE
Fix for HAProxy failing to start when DNS name doesn't resolve at start time

### DIFF
--- a/application/interface/nlb.tf
+++ b/application/interface/nlb.tf
@@ -42,7 +42,7 @@ module "external_nlb" {
   public_zone_id               = "${data.terraform_remote_state.vpc.public_zone_id}"
   private_zone_id              = "${data.terraform_remote_state.vpc.private_zone_id}"
   private_domain               = "${data.terraform_remote_state.vpc.private_zone_name}"
-  alb_fqdn                     = "${module.interface.public_fqdn_internal_alb}"
+  alb_fqdn                     = "${module.interface.private_fqdn_internal_alb}"
   haproxy_instance_type        = "${var.delius_core_haproxy_instance_type}"
   haproxy_instance_count       = "${var.delius_core_haproxy_instance_count}"
 }

--- a/application/interface/weblogic-interface.tf
+++ b/application/interface/weblogic-interface.tf
@@ -142,10 +142,6 @@ output "private_fqdn_interface_wls_internal_alb" {
   value = "${module.interface.private_fqdn_internal_alb}"
 }
 
-output "public_fqdn_interface_wls_internal_alb" {
-  value = "${module.interface.public_fqdn_internal_alb}"
-}
-
 output "newtech_webfrontend_target_group_arn" {
   value = "${module.interface.newtech_webfrontend_targetgroup_arn}"
 }

--- a/application/ndelius/nlb.tf
+++ b/application/ndelius/nlb.tf
@@ -42,7 +42,7 @@ module "external_nlb" {
   public_zone_id               = "${data.terraform_remote_state.vpc.public_zone_id}"
   private_zone_id              = "${data.terraform_remote_state.vpc.private_zone_id}"
   private_domain               = "${data.terraform_remote_state.vpc.private_zone_name}"
-  alb_fqdn                     = "${module.ndelius.public_fqdn_internal_alb}"
+  alb_fqdn                     = "${module.ndelius.private_fqdn_internal_alb}"
   haproxy_instance_type        = "${var.delius_core_haproxy_instance_type}"
   haproxy_instance_count       = "${var.delius_core_haproxy_instance_count}"
 }

--- a/application/ndelius/weblogic-ndelius.tf
+++ b/application/ndelius/weblogic-ndelius.tf
@@ -141,10 +141,6 @@ output "private_fqdn_ndelius_wls_internal_alb" {
   value = "${module.ndelius.private_fqdn_internal_alb}"
 }
 
-output "public_fqdn_ndelius_wls_internal_alb" {
-  value = "${module.ndelius.public_fqdn_internal_alb}"
-}
-
 output "newtech_webfrontend_target_group_arn" {
   value = "${module.ndelius.newtech_webfrontend_targetgroup_arn}"
 }

--- a/application/spg/weblogic-spg.tf
+++ b/application/spg/weblogic-spg.tf
@@ -143,10 +143,6 @@ output "private_fqdn_spg_wls_internal_alb" {
   value = "${module.spg.private_fqdn_internal_alb}"
 }
 
-output "public_fqdn_spg_wls_internal_alb" {
-  value = "${module.spg.public_fqdn_internal_alb}"
-}
-
 output "newtech_webfrontend_target_group_arn" {
   value = "${module.spg.newtech_webfrontend_targetgroup_arn}"
 }

--- a/modules/nlb_to_alb/templates/haproxy.cfg.tpl
+++ b/modules/nlb_to_alb/templates/haproxy.cfg.tpl
@@ -6,8 +6,8 @@ defaults
 
 listen l1
     bind *:80
-    server alb ${alb_fqdn}:80
+    server alb ${alb_fqdn}:80 init-addr last,libc,none
 
 listen l2
     bind *:443
-    server alb ${alb_fqdn}:443
+    server alb ${alb_fqdn}:443 init-addr last,libc,none

--- a/modules/nlb_to_alb/user_data/user_data.haproxy.sh
+++ b/modules/nlb_to_alb/user_data/user_data.haproxy.sh
@@ -4,7 +4,7 @@ exec > >(tee /var/log/user-data.log|logger -t user-data ) 2>&1
 echo BEGIN
 date '+%Y-%m-%d %H:%M:%S'
 
-yum install -y wget git python-pip haproxy
+yum install -y wget git python-pip
 pip install -U pip
 pip install ansible ansible==2.6
 
@@ -65,12 +65,16 @@ export ANSIBLE_LOG_PATH=$HOME/.ansible.log
 ansible-galaxy install -f -r ~/requirements.yml
 CONFIGURE_SWAP=true ansible-playbook ~/bootstrap.yml
 
+# Install HAProxy
+yum install -y centos-release-scl
+yum install -y rh-haproxy18-haproxy rh-haproxy18-haproxy-syspaths
+
 # Configure HAProxy
-mv /etc/haproxy/haproxy.cfg /etc/haproxy/haproxy.cfg.orig
-cat << EOF >> /etc/haproxy/haproxy.cfg
+mv /etc/opt/rh/rh-haproxy18/haproxy/haproxy.cfg /etc/opt/rh/rh-haproxy18/haproxy/haproxy.cfg.orig
+cat << EOF >> /etc/opt/rh/rh-haproxy18/haproxy/haproxy.cfg
 ${haproxy_cfg}
 EOF
 
 # Start HAProxy
-systemctl start haproxy
-systemctl enable haproxy
+systemctl start rh-haproxy18-haproxy
+systemctl enable rh-haproxy18-haproxy

--- a/modules/weblogic-admin-only/internal_alb.tf
+++ b/modules/weblogic-admin-only/internal_alb.tf
@@ -136,20 +136,8 @@ resource "aws_route53_record" "internal_alb_private" {
   records = ["${aws_lb.internal_alb.dns_name}"]
 }
 
-resource "aws_route53_record" "internal_alb_public" {
-  zone_id = "${var.public_zone_id}"
-  name    = "${var.tier_name}-app-internal"
-  type    = "CNAME"
-  ttl     = "300"
-  records = ["${aws_lb.internal_alb.dns_name}"]
-}
-
 output "private_fqdn_internal_alb" {
   value = "${aws_route53_record.internal_alb_private.fqdn}"
-}
-
-output "public_fqdn_internal_alb" {
-  value = "${aws_route53_record.internal_alb_public.fqdn}"
 }
 
 output "newtech_webfrontend_targetgroup_arn" {


### PR DESCRIPTION
See https://discourse.haproxy.org/t/haproxy-fails-to-start-if-backend-server-names-dont-resolve/322/15

Additionally I updated to use the private DNS name instead of the public one, as there's no need to create a public DNS record for the internal load-balancer.