### PR TITLE
Adding security group rule to allow OASys sync.

### DIFF
--- a/security-groups/variables.tf
+++ b/security-groups/variables.tf
@@ -89,3 +89,9 @@ variable "azure_community_proxy_source" {
   type        = "list"
   default     = []
 }
+
+variable "azure_oasys_proxy_source" {
+  description = "Allowed ingress CIDRs from Azure OASys Proxy"
+  type        = "list"
+  default     = []
+}

--- a/security-groups/weblogic-interface.tf
+++ b/security-groups/weblogic-interface.tf
@@ -122,6 +122,18 @@ resource "aws_security_group_rule" "interface_lb_azure_communityproxy_ingress_tl
   description       = "Azure Community Proxy Ingress (TLS)"
 }
 
+resource "aws_security_group_rule" "interface_lb_azure_oasys_ingress_tls" {
+  count = "${length(local.azure_oasys_proxy_source) >= 1  ? 1 : 0}"
+  security_group_id = "${aws_security_group.weblogic_interface_lb.id}"
+  cidr_blocks = [ "${local.azure_oasys_proxy_source}" ]
+  type              = "ingress"
+  protocol          = "tcp"
+  from_port         = "443"
+  to_port           = "443"
+  description       = "Azure OASys Proxy Ingress (TLS)"
+}
+
+
 
 ################################################################################
 ## Instances


### PR DESCRIPTION
This security group rule allows OASys to connect to the interface domain
load balancer.

This connection should be OASys -> Tibco(NDH) -> Azure API GW ->
Interface load balancer.