### PR TITLE
Add DNS runtime to haproxy config.

### DIFF
--- a/modules/nlb_to_alb/data.tf
+++ b/modules/nlb_to_alb/data.tf
@@ -1,7 +1,8 @@
 data "template_file" "haproxy_cfg" {
   template = "${file("${path.module}/templates/haproxy.cfg.tpl")}"
   vars {
-    alb_fqdn = "${var.alb_fqdn}"
+    alb_fqdn       = "${var.alb_fqdn}"
+    aws_nameserver = "${var.aws_nameserver}"
   }
 }
 
@@ -43,7 +44,7 @@ data "aws_ami" "centos" {
   }
 
   filter {
-    name = "root-device-type"
+    name   = "root-device-type"
     values = ["ebs"]
   }
 }

--- a/modules/nlb_to_alb/templates/haproxy.cfg.tpl
+++ b/modules/nlb_to_alb/templates/haproxy.cfg.tpl
@@ -4,10 +4,16 @@ defaults
     timeout client 5m
     timeout server 5m
 
+resolvers vpcresolver
+    nameserver awsdns ${aws_nameserver}:53
+    resolve_retries 30
+    timeout retry 1s
+    hold valid 10s
+
 listen l1
     bind *:80
-    server alb ${alb_fqdn}:80 init-addr last,libc,none
+    server httpalb ${alb_fqdn}:80 check resolvers vpcresolver
 
 listen l2
     bind *:443
-    server alb ${alb_fqdn}:443 init-addr last,libc,none
+    server httpsalb ${alb_fqdn}:443 check resolvers vpcresolver

--- a/modules/nlb_to_alb/variables.tf
+++ b/modules/nlb_to_alb/variables.tf
@@ -99,6 +99,11 @@ variable "alb_fqdn" {
   type        = "string"
 }
 
+variable "aws_nameserver" {
+  description = "IP of the VPC DNS resolver"
+  type        = string
+}
+
 variable "haproxy_instance_type" {
   description = "Instance type to use for the HAProxy instances"
   type        = "string"


### PR DESCRIPTION
This changes haproxy from using startup to runtime DNS lookups for the IP addresses of the ALB it is talking to.

Doing this as the ALB will change IP address internally and this has caused some downtime.