### PR TITLE
This puts the management server after the LDAP as it has a dependency…

### DIFF
--- a/apply_dcore_tf_pipeline.Jenkinsfile
+++ b/apply_dcore_tf_pipeline.Jenkinsfile
@@ -296,7 +296,7 @@ pipeline {
 
         stage('Build Delius Database High Availibilty') {
             steps {
-                println("batch/dss")
+                println("Build Database High Availibilty")
                 build job: "DAMS/Environments/${environment_name}/Delius/Build_Oracle_DB_HA", parameters: [[$class: 'StringParameterValue', name: 'environment_name', value: "${environment_name}"]]
             }
         }

--- a/apply_dcore_tf_pipeline.Jenkinsfile
+++ b/apply_dcore_tf_pipeline.Jenkinsfile
@@ -150,7 +150,7 @@ pipeline {
                   git url: 'git@github.com:ministryofjustice/' + project.config, branch: 'master', credentialsId: 'f44bc5f1-30bd-4ab9-ad61-cc32caf1562a'
                 }
                 dir( project.dcore ) {
-                  git url: 'git@github.com:ministryofjustice/' + project.dcore, branch: 'delius-stage_to_prod_access_build', credentialsId: 'f44bc5f1-30bd-4ab9-ad61-cc32caf1562a'
+                  git url: 'git@github.com:ministryofjustice/' + project.dcore, branch: 'master', credentialsId: 'f44bc5f1-30bd-4ab9-ad61-cc32caf1562a'
                 }
 
                 prepare_env()

--- a/apply_dcore_tf_pipeline.Jenkinsfile
+++ b/apply_dcore_tf_pipeline.Jenkinsfile
@@ -165,15 +165,6 @@ pipeline {
           }
         }
 
-        stage('Delius Backups bucket') {
-          steps {
-            script {
-              println("No Buckets (place holder while this is established during PROD golive fixes)")
-              // do_terraform(project.config, environment_name, project.dcore, 's3buckets')
-            }
-          }
-        }
-
         stage('Delius Keys and Profiles') {
           steps {
             script {

--- a/apply_dcore_tf_pipeline.Jenkinsfile
+++ b/apply_dcore_tf_pipeline.Jenkinsfile
@@ -261,7 +261,7 @@ pipeline {
             }
         }
 
-        stage ('Delius Weblogics') {
+        stage ('Delius supporting tasks') {
             parallel {
                   stage ('Delius DSS Batch Job') {
                     steps{

--- a/apply_dcore_tf_pipeline.Jenkinsfile
+++ b/apply_dcore_tf_pipeline.Jenkinsfile
@@ -275,7 +275,7 @@ pipeline {
                   stage('Build Delius Database High Availibilty') {
                       steps {
                           println("batch/dss")
-                          // build job: "DAMS/Environments/${environment_name}/Delius/Build_Oracle_DB_HA", parameters: [[$class: 'StringParameterValue', name: 'environment_name', value: "${environment_name}"]]
+                          build job: "DAMS/Environments/${environment_name}/Delius/Build_Oracle_DB_HA", parameters: [[$class: 'StringParameterValue', name: 'environment_name', value: "${environment_name}"]]
                       }
                   }
 

--- a/apply_dcore_tf_pipeline.Jenkinsfile
+++ b/apply_dcore_tf_pipeline.Jenkinsfile
@@ -265,7 +265,7 @@ pipeline {
             }
         }
 
-        stage ('Monitoring and ') {
+        stage ('Monitoring and Batch') {
             parallel {
                 stage ('Delius DSS Batch Job') {
                     steps{


### PR DESCRIPTION
… on it.

Also put building of weblogics in parallel to speed up pipeline. Put catch around so the pipeline will finish building other non dependent resources.
Put the DB HA and remaining stages into a parallel stage to speed up the pipe line. Also catch set to enable pipeline to finish as explained above.
The smoke test will still rely on the completiong of the previous stages however nothing is held up by the DB HA stage now.

Closes #277 