### PR TITLE
Added config to match latest UMT changes (oid.* -> spring.ldap.*) 

### DIFF
--- a/application/umt/templates/ecs/container_definition.json.tpl
+++ b/application/umt/templates/ecs/container_definition.json.tpl
@@ -30,6 +30,10 @@
         { "name": "SPRING_DATASOURCE_TYPE", "value": "oracle.jdbc.pool.OracleDataSource" },
         { "name": "SPRING_JPA_PROPERTIES_HIBERNATE_DIALECT", "value": "org.hibernate.dialect.Oracle10gDialect" },
         { "name": "SPRING_JPA_HIBERNATE_DDL-AUTO", "value": "none" },
+        { "name": "SPRING_LDAP_URLS", "value": "${ldap_url}" },
+        { "name": "SPRING_LDAP_USERNAME", "value": "${ldap_username}" },
+        { "name": "SPRING_LDAP_BASE", "value": "${ldap_base}" },
+        { "name": "SPRING_LDAP_USEORACLEATTRIBUTES", "value": "false" },
 
         { "name": "OID_URLS", "value": "${ldap_url}" },
         { "name": "OID_USERNAME", "value": "${ldap_username}" },

--- a/application/umt/templates/ecs/container_definition.json.tpl
+++ b/application/umt/templates/ecs/container_definition.json.tpl
@@ -56,6 +56,10 @@
             "valueFrom": "arn:aws:ssm:${region}:${aws_account_id}:parameter/${environment_name}/${project_name}/delius-database/db/delius_app_schema_password"
         },
         {
+            "name": "SPRING_LDAP_PASSWORD",
+            "valueFrom": "arn:aws:ssm:${region}:${aws_account_id}:parameter/${environment_name}/${project_name}/apacheds/apacheds/ldap_admin_password"
+        },
+        {
             "name": "OID_PASSWORD",
             "valueFrom": "arn:aws:ssm:${region}:${aws_account_id}:parameter/${environment_name}/${project_name}/apacheds/apacheds/ldap_admin_password"
         }


### PR DESCRIPTION
The old keys have been left in there too until the latest version has been deployed everywhere, so that deployments of UMT <= 1.6.6 still work.