### PR TITLE
Removed aptracker secret

### DIFF
--- a/modules/weblogic-admin-only/user_data/user_data.interface.sh
+++ b/modules/weblogic-admin-only/user_data/user_data.interface.sh
@@ -166,7 +166,6 @@ weblogic_admin_password="$(echo $PARAM | jq '.[] | select(.Name | test("weblogic
 ldap_admin_password="$(echo $PARAM | jq '.[] | select(.Name | test("ldap_admin_password")) | .Value' --raw-output)"
 database_password="$(echo $PARAM | jq '.[] | select(.Name | test("delius_pool_password")) | .Value' --raw-output)"
 usermanagement_secret="$(echo $PARAM | jq '.[] | select(.Name | test("umt/delius_secret")) | .Value' --raw-output)"
-aptracker_api_errors_secret="$(echo $PARAM | jq '.[] | select(.Name | test("errors_ui/delius_secret")) | .Value' --raw-output)"
 
 export ANSIBLE_LOG_PATH=$HOME/.ansible.log
 
@@ -177,6 +176,5 @@ CONFIGURE_SWAP=true ansible-playbook ~/bootstrap.yml \
 'ldap_admin_password':'$ldap_admin_password', \
 'database_password':'$database_password', \
 'usermanagement_secret':'$usermanagement_secret', \
-'aptracker_api_errors_secret':'$aptracker_api_errors_secret', \
 'instance_id':'$INSTANCE_ID' \
 }"

--- a/modules/weblogic-admin-only/user_data/user_data.ndelius.sh
+++ b/modules/weblogic-admin-only/user_data/user_data.ndelius.sh
@@ -165,7 +165,6 @@ weblogic_admin_password="$(echo $PARAM | jq '.[] | select(.Name | test("weblogic
 ldap_admin_password="$(echo $PARAM | jq '.[] | select(.Name | test("ldap_admin_password")) | .Value' --raw-output)"
 database_password="$(echo $PARAM | jq '.[] | select(.Name | test("delius_pool_password")) | .Value' --raw-output)"
 usermanagement_secret="$(echo $PARAM | jq '.[] | select(.Name | test("umt/delius_secret")) | .Value' --raw-output)"
-aptracker_api_errors_secret="$(echo $PARAM | jq '.[] | select(.Name | test("errors_ui/delius_secret")) | .Value' --raw-output)"
 
 export ANSIBLE_LOG_PATH=$HOME/.ansible.log
 
@@ -176,6 +175,5 @@ CONFIGURE_SWAP=true ansible-playbook ~/bootstrap.yml \
 'ldap_admin_password':'$ldap_admin_password', \
 'database_password':'$database_password', \
 'usermanagement_secret':'$usermanagement_secret', \
-'aptracker_api_errors_secret':'$aptracker_api_errors_secret', \
 'instance_id':'$INSTANCE_ID' \
 }"

--- a/modules/weblogic-admin-only/user_data/user_data.spg.sh
+++ b/modules/weblogic-admin-only/user_data/user_data.spg.sh
@@ -181,7 +181,6 @@ weblogic_admin_password="$(echo $PARAM | jq '.[] | select(.Name | test("weblogic
 ldap_admin_password="$(echo $PARAM | jq '.[] | select(.Name | test("ldap_admin_password")) | .Value' --raw-output)"
 database_password="$(echo $PARAM | jq '.[] | select(.Name | test("delius_pool_password")) | .Value' --raw-output)"
 usermanagement_secret="$(echo $PARAM | jq '.[] | select(.Name | test("umt/delius_secret")) | .Value' --raw-output)"
-aptracker_api_errors_secret="$(echo $PARAM | jq '.[] | select(.Name | test("errors_ui/delius_secret")) | .Value' --raw-output)"
 remote_broker_username="$(echo $PARAM | jq '.[] | select(.Name | test("remote_broker_username")) | .Value' --raw-output)"
 remote_broker_password="$(echo $PARAM | jq '.[] | select(.Name | test("remote_broker_password")) | .Value' --raw-output)"
 
@@ -195,7 +194,6 @@ CONFIGURE_SWAP=true ansible-playbook ~/bootstrap.yml \
 'ldap_admin_password':'$ldap_admin_password', \
 'database_password':'$database_password', \
 'usermanagement_secret':'$usermanagement_secret', \
-'aptracker_api_errors_secret':'$aptracker_api_errors_secret', \
 'activemq_remoteCF_username':'$remote_broker_username', \
 'activemq_remoteCF_password':'$remote_broker_password', \
 'instance_id':'$INSTANCE_ID' \


### PR DESCRIPTION
Auth is now handled within UMT so only the usermanagement_secret is required for encrypting preauthenticated user details.