### PR TITLE
ALS-200 Disable scaling of GDPR API service

### DIFF
--- a/application/gdpr/api-service.tf
+++ b/application/gdpr/api-service.tf
@@ -15,6 +15,7 @@ resource "aws_ecs_service" "api_service" {
   name            = "${var.short_environment_name}-${local.api_name}-service"
   cluster         = "${data.terraform_remote_state.ecs_cluster.shared_ecs_cluster_id}"
   task_definition = "${aws_ecs_task_definition.api_task_definition.arn}"
+  desired_count   = 1 # Fix to a single instance, as currently the batch processes cannot be scaled horizontally
   load_balancer {
     container_name   = "${local.api_name}"
     container_port   = 8080
@@ -46,39 +47,6 @@ resource "aws_ecs_service" "api_service" {
     ]
   }
   depends_on = ["aws_iam_role.task"]
-  lifecycle {
-    ignore_changes = ["desired_count"]
-  }
-}
-
-# ECS autoscaling
-resource "aws_appautoscaling_target" "api_scaling_target" {
-  min_capacity       = "${local.gdpr_config["scaling_min_capacity"]}"
-  max_capacity       = "${local.gdpr_config["scaling_max_capacity"]}"
-  resource_id        = "service/${data.terraform_remote_state.ecs_cluster.shared_ecs_cluster_name}/${aws_ecs_service.api_service.name}"
-  role_arn           = "${aws_iam_role.exec.arn}"
-  scalable_dimension = "ecs:service:DesiredCount"
-  service_namespace  = "ecs"
-
-  # Use lifecycle rule as workaround for role_arn being changed every time due to
-  # role_arn being required field but AWS will always switch this to the auto created service role
-  lifecycle {
-    ignore_changes = "role_arn"
-  }
-}
-
-resource "aws_appautoscaling_policy" "api_scaling_policy" {
-  name                       = "${var.environment_name}-${local.api_name}-cpu-scaling-policy"
-  policy_type                = "TargetTrackingScaling"
-  resource_id                = "${aws_appautoscaling_target.api_scaling_target.resource_id}"
-  scalable_dimension         = "${aws_appautoscaling_target.api_scaling_target.scalable_dimension}"
-  service_namespace          = "${aws_appautoscaling_target.api_scaling_target.service_namespace}"
-  target_tracking_scaling_policy_configuration {
-    predefined_metric_specification {
-      predefined_metric_type = "ECSServiceAverageCPUUtilization"
-    }
-    target_value             = "${local.gdpr_config["target_cpu"]}"
-  }
 }
 
 # Create a service record in the ecs cluster's private namespace

--- a/application/gdpr/ui-service.tf
+++ b/application/gdpr/ui-service.tf
@@ -53,8 +53,8 @@ resource "aws_ecs_service" "ui_service" {
 
 # ECS autoscaling
 resource "aws_appautoscaling_target" "ui_scaling_target" {
-  min_capacity       = "${local.gdpr_config["scaling_min_capacity"]}"
-  max_capacity       = "${local.gdpr_config["scaling_max_capacity"]}"
+  min_capacity       = "${local.gdpr_config["ui_scaling_min_capacity"]}"
+  max_capacity       = "${local.gdpr_config["ui_scaling_max_capacity"]}"
   resource_id        = "service/${data.terraform_remote_state.ecs_cluster.shared_ecs_cluster_name}/${aws_ecs_service.ui_service.name}"
   role_arn           = "${aws_iam_role.exec.arn}"
   scalable_dimension = "ecs:service:DesiredCount"
@@ -77,7 +77,7 @@ resource "aws_appautoscaling_policy" "ui_scaling_policy" {
     predefined_metric_specification {
       predefined_metric_type = "ECSServiceAverageCPUUtilization"
     }
-    target_value             = "${local.gdpr_config["target_cpu"]}"
+    target_value             = "${local.gdpr_config["ui_target_cpu"]}"
   }
 }
 

--- a/application/gdpr/variables.tf
+++ b/application/gdpr/variables.tf
@@ -29,29 +29,8 @@ variable "default_gdpr_config" {
   description = "Default values to be overridden by gdpr_config. This should match the intended config for production."
   type = "map"
   default = {
-    api_image_url               = "895523100917.dkr.ecr.eu-west-2.amazonaws.com/hmpps/delius-gdpr"
-    api_version                 = "0.11"                 # Application version
-    api_memory                  = 4196                   # Memory to assign to API container
-    api_cpu                     = 2048                   # CPU to assign to API container
-    cron_identifyduplicates     = "-"                    # Batch schedules. Set to "-" to disable.
-    cron_retainedoffenders      = "-"                    #
-    cron_retainedoffendersiicsa = "-"                    #
-    cron_eligiblefordeletion    = "-"                    #
-    cron_deleteoffenders        = "-"                    #
-    cron_destructionlogclearing = "-"                    #
-    ui_image_url                = "895523100917.dkr.ecr.eu-west-2.amazonaws.com/hmpps/delius-gdpr-ui"
-    ui_version                  = "0.11"                 # Application version
-    ui_memory                   = 1024                   # Memory to assign to UI container
-    ui_cpu                      = 1024                   # CPU to assign to UI container
-    db_instance_class           = "db.m5.large"          # Instance type to use for the database
-    db_storage                  = 100                    # Allocated database storage in GB
-    db_maintenance_window       = "Wed:21:00-Wed:23:00"  # Maintenance window for database patching/upgrades
-    db_backup_window            = "19:00-21:00"          # Daily window to take RDS backups
-    db_backup_retention_period  = 14                     # Number of days to retain RDS backups for
-    scaling_min_capacity        = 2                      # Minimum number of running tasks per service
-    scaling_max_capacity        = 10                     # Maximum number of running tasks per service
-    target_cpu                  = 60                     # CPU target value for scaling of ECS tasks
-    log_level                   = "INFO"                 # Application log-level
+    # See https://github.com/ministryofjustice/hmpps-env-configs/blob/master/common/common.tfvars
+    #     https://github.com/ministryofjustice/hmpps-env-configs/blob/master/common/common-prod.tfvars
   }
 }
 


### PR DESCRIPTION
Required due to lack of horizontal scaling built in to the batch processing. If performance is an issue we may need to vertically scale for the time being.