### PR TITLE
Ensure older versions of UMT (<1.7) can still be deployed

### DIFF
--- a/application/umt/templates/ecs/container_definition.json.tpl
+++ b/application/umt/templates/ecs/container_definition.json.tpl
@@ -50,7 +50,7 @@
 
         { "name": "OID_URLS",               "value": "${ldap_url}" },
         { "name": "OID_USERNAME",           "value": "${ldap_username}" },
-        { "name": "OID_BASE",               "value": "${ldap_base}" },
+        { "name": "OID_BASE",               "value": "${ldap_base_users},${ldap_base}" },
         { "name": "OID_USEORACLEATTRIBUTES","value": "false" }
     ],
     "secrets": [


### PR DESCRIPTION
The LDAP base config was changed from `ou=Users,dc=moj,dc=com` to `dc=moj,dc=com` so that groups could also be managed, however UMT 1.6.6 and below still need the `ou=Users` part in there.

UMT 1.6.6 and below uses the OID_BASE config property, whereas newer versions use SPRING_LDAP_BASE - which allows us to properly support both older and newer versions by setting:
OID_BASE=ou=Users,dc=moj,dc=com
SPRING_LDAP_BASE=dc=moj,dc=com