### PR TITLE
Fix typo in server.forward-headers-strategy var

### DIFF
--- a/application/umt/templates/ecs/container_definition.json.tpl
+++ b/application/umt/templates/ecs/container_definition.json.tpl
@@ -26,7 +26,7 @@
     "entryPoint": ["java","-Duser.timezone=Europe/London","-jar","/app/app.jar"],
     "environment": [
         { "name": "SERVER_USE-FORWARD-HEADERS",             "value": "true" },
-        { "name": "SERVER_FORWARD-HEADER-STRATEGY",         "value": "native" },
+        { "name": "SERVER_FORWARD-HEADERS-STRATEGY",        "value": "native" },
         { "name": "SPRING_DATASOURCE_URL",                  "value": "${database_url}" },
         { "name": "SPRING_DATASOURCE_USERNAME",             "value": "${database_username}" },
         { "name": "SPRING_DATASOURCE_TYPE",                 "value": "oracle.jdbc.pool.OracleDataSource" },


### PR DESCRIPTION
See deprecation notice of:
https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.2-Release-Notes#deprecations-in-spring-boot-22

We had a typo in `server.forward-headers-strategy` (missing 's' in headers), which meant we were still relying on the deprecated feature. This has been removed in 2.3.0 so the OAuth2 /authorize endpoint had started redirecting to the login page on HTTP and not HTTPS.