### PR TITLE
Shorten the short_environment_name

### DIFF
--- a/modules/ecs_service/locals.tf
+++ b/modules/ecs_service/locals.tf
@@ -1,4 +1,5 @@
 locals {
   name       = "${var.short_environment_name}-${var.service_name}"
-  short_name = "${format("%.28s", local.name)}"                    # Truncated to a max of 28 chars, for resources that have a limit on name length (eg. target group)
+  short_env  = "${format("%.12s", var.short_environment_name)}"               # Because the short_environment_name isn't that short...
+  short_name = "${format("%.28s", "${local.short_env}-${var.service_name}")}" # For resources that have a limit on name length (eg. target group)
 }


### PR DESCRIPTION
(to account for 'dtt-training-test' being too long)