### PR TITLE
Pinned the hmpps-oracle-database git repo version for modules//oracle…

### DIFF
--- a/database/server-delius-db.tf
+++ b/database/server-delius-db.tf
@@ -1,5 +1,5 @@
 module "delius_db" {
-  source      = "git::https://github.com/ministryofjustice/hmpps-oracle-database.git?ref=master//modules//oracle-database"
+  source      = "git::https://github.com/ministryofjustice/hmpps-oracle-database.git?ref=0.5.0//modules//oracle-database"
   server_name = "delius-db"
 
   ami_id               = "${data.aws_ami.centos_oracle_db.id}"

--- a/database_failover/server-delius-db-1.tf
+++ b/database_failover/server-delius-db-1.tf
@@ -7,7 +7,7 @@ locals {
 }
 
 module "delius_db_1" {
-  source      = "git::https://github.com/ministryofjustice/hmpps-oracle-database.git?ref=master//modules//oracle-database"
+  source      = "git::https://github.com/ministryofjustice/hmpps-oracle-database.git?ref=0.5.0//modules//oracle-database"
   server_name = "delius-db-1"
 
   ami_id               = "${data.aws_ami.centos_oracle_db.id}"

--- a/database_standbydb1/server-delius-db-2.tf
+++ b/database_standbydb1/server-delius-db-2.tf
@@ -1,5 +1,5 @@
 module "delius_db_2" {
-  source      = "git::https://github.com/ministryofjustice/hmpps-oracle-database.git?ref=master//modules//oracle-database"
+  source      = "git::https://github.com/ministryofjustice/hmpps-oracle-database.git?ref=0.5.0//modules//oracle-database"
   server_name = "delius-db-2"
 
   ami_id               = "${data.aws_ami.centos_oracle_db.id}"

--- a/database_standbydb2/server-delius-db-3.tf
+++ b/database_standbydb2/server-delius-db-3.tf
@@ -1,5 +1,5 @@
 module "delius_db_3" {
-  source      = "git::https://github.com/ministryofjustice/hmpps-oracle-database.git?ref=master//modules//oracle-database"
+  source      = "git::https://github.com/ministryofjustice/hmpps-oracle-database.git?ref=0.5.0//modules//oracle-database"
   server_name = "delius-db-3"
 
   ami_id               = "${data.aws_ami.centos_oracle_db.id}"


### PR DESCRIPTION
…-database to tag 0.5.0 (current head) to ensure some breaking changes are not applied during other operations on the Delius-Core terraform pipeline.