### PR TITLE
Added create_before_destroy to compute environment, to prevent 'cannot delete' error with existing batch queue

### DIFF
--- a/modules/scheduled_batch/batch_environment/main.tf
+++ b/modules/scheduled_batch/batch_environment/main.tf
@@ -42,7 +42,7 @@ resource "aws_iam_instance_profile" "ecs_instance_profile" {
 }
 
 resource "aws_batch_compute_environment" "batch_ce" {
-  compute_environment_name = "${var.ce_name}-ce"
+  compute_environment_name_prefix = "${var.ce_name}-ce"
 
   compute_resources {
     instance_role = "${aws_iam_instance_profile.ecs_instance_profile.arn}"
@@ -70,6 +70,7 @@ resource "aws_batch_compute_environment" "batch_ce" {
     ignore_changes = [
       "compute_resources.0.desired_vcpus",
     ]
+    create_before_destroy = true
   }
 }
 


### PR DESCRIPTION
Fixes:
```
* module.dss_batch_environment.aws_batch_compute_environment.batch_ce (destroy): 1 error(s) occurred:

* aws_batch_compute_environment.batch_ce: error deleting Batch Compute Environment (delius-int-ndelius-ce): : Cannot delete, found existing JobQueue relationship
	status code: 400, request id: 2762a5e5-108e-4a54-9c6c-25c4c9dee9d2
```


AWS doesn't allow tags to be updated on existing Batch Compute Environment resources, so a tag update forces destroy/recreation of the resource by Terraform. However Terraform doesn't automatically destroy/recreate the JobQueue as well, so we get a failure trying to destroy the Compute Environment because there is an existing relationship between the two.

This change ensures the new Compute Environment is created first, then the JobQueue is switched over to the new one. This allows Terraform to successfully destroy the old Compute Environment because no JobQueue relationships exist for it.