### PR TITLE
Adding the policy to enable the "server_provision_ec2_role" access to…

### DIFF
--- a/key_profile/instance_profile.tf
+++ b/key_profile/instance_profile.tf
@@ -7,6 +7,7 @@ module "server_provision_ec2_role" {
   dependencies_bucket_arn = "${var.dependencies_bucket_arn}"
   s3_oracledb_backups_arn = "${data.terraform_remote_state.s3-oracledb-backups.s3_oracledb_backups.arn}"
   s3_ldap_backups_arn     = "${data.terraform_remote_state.s3-ldap-backups.s3_ldap_backups.arn}"
+  s3_test_results_arn     = "${data.terraform_remote_state.s3-test-results.s3_test_results.arn}"
   migration_bucket_arn    = "${var.migration_bucket_arn}"
 }
 

--- a/key_profile/main.tf
+++ b/key_profile/main.tf
@@ -48,7 +48,7 @@ data "terraform_remote_state" "s3-oracledb-backups" {
 }
 
 #-------------------------------------------------------------
-### Getting the oracledb backup s3 bucket
+### Getting the ldap backup s3 bucket
 #-------------------------------------------------------------
 data "terraform_remote_state" "s3-ldap-backups" {
   backend = "s3"
@@ -56,6 +56,19 @@ data "terraform_remote_state" "s3-ldap-backups" {
   config {
     bucket = "${var.remote_state_bucket_name}"
     key    = "s3/ldap-backups/terraform.tfstate"
+    region = "${var.region}"
+  }
+}
+
+#-------------------------------------------------------------
+### Getting the test results s3 bucket
+#-------------------------------------------------------------
+data "terraform_remote_state" "s3-test-results" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket_name}"
+    key    = "s3/test-results/terraform.tfstate"
     region = "${var.region}"
   }
 }

--- a/modules/iam_roles/server_provision_ec2_role/main.tf
+++ b/modules/iam_roles/server_provision_ec2_role/main.tf
@@ -18,6 +18,7 @@ data "template_file" "bucket_access_policy" {
     dependencies_bucket_arn = "${var.dependencies_bucket_arn}"
     s3_oracledb_backups_arn = "${var.s3_oracledb_backups_arn}"
     s3_ldap_backups_arn     = "${var.s3_ldap_backups_arn}"
+    s3_test_results_arn     = "${var.s3_test_results_arn}"
     migration_bucket_arn    = "${var.migration_bucket_arn}"
   }
 }

--- a/modules/iam_roles/server_provision_ec2_role/policies/bucket_access_policy_template.json
+++ b/modules/iam_roles/server_provision_ec2_role/policies/bucket_access_policy_template.json
@@ -47,6 +47,17 @@
       ]
     },
     {
+      "Sid": "allowAccessToTestResultsBucket",
+      "Effect": "Allow",
+      "Action": [
+        "s3:*"
+      ],
+      "Resource": [
+        "${s3_test_results_arn}",
+        "${s3_test_results_arn}/*"
+      ]
+    },
+    {
       "Sid": "allowAccessToMigrationBucket",
       "Effect": "Allow",
       "Action": [

--- a/modules/iam_roles/server_provision_ec2_role/variables.tf
+++ b/modules/iam_roles/server_provision_ec2_role/variables.tf
@@ -18,6 +18,10 @@ variable "s3_ldap_backups_arn" {
   description = "The S3 bucket arn for ldap ldif backups"
 }
 
+variable "s3_test_results_arn" {
+  description = "The S3 bucket arn for performance test results"
+}
+
 variable "migration_bucket_arn" {
   description = "The S3 bucket arn for temporarily holding migrated data"
 }


### PR DESCRIPTION
… the environment's test results S3 Bucket.

Tested in delius-perf and this change in delius-cored-dev

`------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  ~ module.server_provision_ec2_role.aws_iam_policy.delius_core_dependencies_bucket_access
      policy: "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Sid\": \"listAllBuckets\",\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"s3:ListAllMyBuckets\",\n                \"s3:GetBucketLocation\"\n            ],\n            \"Resource\": [\n                \"arn:aws:s3:::*\"\n            ]\n        },\n        {\n            \"Sid\": \"allowAccessToDependenciesBucket\",\n            \"Action\": [\n                \"s3:Get*\",\n                \"s3:List*\"\n            ],\n            \"Effect\": \"Allow\",\n            \"Resource\": [\n                \"arn:aws:s3:::tf-eu-west-2-hmpps-eng-dev-delius-core-dependencies-s3bucket\",\n                \"arn:aws:s3:::tf-eu-west-2-hmpps-eng-dev-delius-core-dependencies-s3bucket/*\"\n            ]\n        },\n        {\n            \"Sid\": \"allowAccessToOracleDBBackupBucket\",\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"s3:*\"\n            ],\n            \"Resource\": [\n                \"arn:aws:s3:::eu-west-2-dlc-dev-oracledb-backups\",\n                \"arn:aws:s3:::eu-west-2-dlc-dev-oracledb-backups/*\"\n            ]\n        },\n        {\n            \"Sid\": \"allowAccessToLDAPBackupBucket\",\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"s3:*\"\n            ],\n            \"Resource\": [\n                \"arn:aws:s3:::eu-west-2-dlc-dev-ldap-backups\",\n                \"arn:aws:s3:::eu-west-2-dlc-dev-ldap-backups/*\"\n            ]\n        },\n        {\n            \"Sid\": \"allowAccessToMigrationBucket\",\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"s3:Get*\",\n                \"s3:List*\"\n            ],\n            \"Resource\": [\n                \"arn:aws:s3:::tf-eu-west-2-hmpps-eng-prod-artefacts-s3bucket\",\n                \"arn:aws:s3:::tf-eu-west-2-hmpps-eng-prod-artefacts-s3bucket/*\"\n            ]\n        }\n    ]\n}" => "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Sid\": \"listAllBuckets\",\n      \"Effect\": \"Allow\",\n      \"Action\": [\n        \"s3:ListAllMyBuckets\",\n        \"s3:GetBucketLocation\"\n      ],\n      \"Resource\": [\n        \"arn:aws:s3:::*\"\n      ]\n    },\n    {\n      \"Sid\": \"allowAccessToDependenciesBucket\",\n      \"Action\": [\n        \"s3:Get*\",\n        \"s3:List*\"\n      ],\n      \"Effect\": \"Allow\",\n      \"Resource\": [\n        \"arn:aws:s3:::tf-eu-west-2-hmpps-eng-dev-delius-core-dependencies-s3bucket\",\n        \"arn:aws:s3:::tf-eu-west-2-hmpps-eng-dev-delius-core-dependencies-s3bucket/*\"\n      ]\n    },\n    {\n      \"Sid\": \"allowAccessToOracleDBBackupBucket\",\n      \"Effect\": \"Allow\",\n      \"Action\": [\n        \"s3:*\"\n      ],\n      \"Resource\": [\n        \"arn:aws:s3:::eu-west-2-dlc-dev-oracledb-backups\",\n        \"arn:aws:s3:::eu-west-2-dlc-dev-oracledb-backups/*\"\n      ]\n    },\n    {\n      \"Sid\": \"allowAccessToLDAPBackupBucket\",\n      \"Effect\": \"Allow\",\n      \"Action\": [\n        \"s3:*\"\n      ],\n      \"Resource\": [\n        \"arn:aws:s3:::eu-west-2-dlc-dev-ldap-backups\",\n        \"arn:aws:s3:::eu-west-2-dlc-dev-ldap-backups/*\"\n      ]\n    },\n    {\n      \"Sid\": \"allowAccessToTestResultsBucket\",\n      \"Effect\": \"Allow\",\n      \"Action\": [\n        \"s3:*\"\n      ],\n      \"Resource\": [\n        \"arn:aws:s3:::eu-west-2-dlc-dev-test-results\",\n        \"arn:aws:s3:::eu-west-2-dlc-dev-test-results/*\"\n      ]\n    },\n    {\n      \"Sid\": \"allowAccessToMigrationBucket\",\n      \"Effect\": \"Allow\",\n      \"Action\": [\n        \"s3:Get*\",\n        \"s3:List*\"\n      ],\n      \"Resource\": [\n        \"arn:aws:s3:::tf-eu-west-2-hmpps-eng-prod-artefacts-s3bucket\",\n        \"arn:aws:s3:::tf-eu-west-2-hmpps-eng-prod-artefacts-s3bucket/*\"\n      ]\n    }\n  ]\n}\n"


Plan: 0 to add, 1 to change, 0 to destroy.

------------------------------------------------------------------------`