### PR TITLE
ALS-2481 Reduce root volume size based on usage.

### DIFF
--- a/modules/nlb_to_alb/haproxy_asg.tf
+++ b/modules/nlb_to_alb/haproxy_asg.tf
@@ -13,7 +13,7 @@ resource "aws_launch_configuration" "haproxy_launch_cfg" {
 
   root_block_device {
     volume_type = "gp2"
-    volume_size = 50
+    volume_size = 32
   }
 
   lifecycle {

--- a/modules/weblogic-admin-only/asg.tf
+++ b/modules/weblogic-admin-only/asg.tf
@@ -26,7 +26,7 @@ resource "aws_launch_configuration" "wls_launch_cfg" {
 
   root_block_device {
     volume_type = "gp2"
-    volume_size = 50
+    volume_size = 32
   }
 
   lifecycle {


### PR DESCRIPTION
Each instance creates a 16GB swap file on the root device + uses up to 3-4GB for logs and artefacts. So 32GB still leaves plenty of head room.