### PR TITLE
Dynamically ignore changes to the task definition

### DIFF
--- a/application/delius-api/ecs.tf
+++ b/application/delius-api/ecs.tf
@@ -22,10 +22,11 @@ module "ecs" {
   target_cpu_usage  = local.app_config["target_cpu"]
   health_check_path = "/health"
 
+  ignore_task_definition_changes = true # Managed by Circle CI
   container_definition = jsonencode([{
     essential    = true
     name         = local.app_name
-    image        = "${local.app_config["image_url"]}:${aws_ssm_parameter.image_version.value}"
+    image        = "${local.app_config["image_url"]}:latest"
     cpu          = tonumber(local.app_config["cpu"])
     memory       = tonumber(local.app_config["memory"])
     portMappings = [{ hostPort = 8080, containerPort = 8080 }]

--- a/application/delius-api/ssm.tf
+++ b/application/delius-api/ssm.tf
@@ -1,9 +1,0 @@
-resource "aws_ssm_parameter" "image_version" {
-  name        = "/versions/delius-core/ecs/delius-api/${var.environment_name}"
-  value       = "latest"
-  type        = "String"
-  description = "Delius-API image version. Managed by CircleCI."
-  lifecycle {
-    ignore_changes = [value]
-  }
-}

--- a/modules/ecs_service/data.tf
+++ b/modules/ecs_service/data.tf
@@ -40,3 +40,8 @@ data "template_file" "ecs_exec_policy_template" {
   }
 }
 
+data "external" "current_task_definition" {
+  # Fetch the currently assigned task definition, this is used when var.ignore_task_definition_changes is true.
+  # We use an external data source (instead of ignore_changes) for this, as a workaround for: https://github.com/hashicorp/terraform/issues/24188
+  program = ["sh", "-c", "aws ecs describe-services --cluster '${var.ecs_cluster["name"]}' --services '${local.name}-service' --region '${var.region}' --query '{arn: services[0].taskDefinition}' || echo {\"arn\":\"\"}"]
+}

--- a/modules/ecs_service/ecs.tf
+++ b/modules/ecs_service/ecs.tf
@@ -13,7 +13,7 @@ resource "aws_ecs_task_definition" "task_definition" {
 resource "aws_ecs_service" "service" {
   name            = "${local.name}-service"
   cluster         = var.ecs_cluster["cluster_id"]
-  task_definition = var.ignore_task_definition_changes ? data.external.current_task_definition.result.arn : aws_ecs_task_definition.task_definition.arn
+  task_definition = var.ignore_task_definition_changes && data.external.current_task_definition.result.arn != "" ? data.external.current_task_definition.result.arn : aws_ecs_task_definition.task_definition.arn
 
   deployment_controller {
     type = var.deployment_controller

--- a/modules/ecs_service/ecs.tf
+++ b/modules/ecs_service/ecs.tf
@@ -13,7 +13,7 @@ resource "aws_ecs_task_definition" "task_definition" {
 resource "aws_ecs_service" "service" {
   name            = "${local.name}-service"
   cluster         = var.ecs_cluster["cluster_id"]
-  task_definition = aws_ecs_task_definition.task_definition.arn
+  task_definition = var.ignore_task_definition_changes ? data.external.current_task_definition.result.arn : aws_ecs_task_definition.task_definition.arn
 
   deployment_controller {
     type = var.deployment_controller

--- a/modules/ecs_service/variables.tf
+++ b/modules/ecs_service/variables.tf
@@ -127,6 +127,11 @@ variable "deregistration_delay" {
   default     = 60
 }
 
+variable "ignore_task_definition_changes" {
+  description = "Whether to ignore changes to the registered task definition for the service. Useful for externally-managed deployments."
+  default     = false
+}
+
 variable "tags" {
   description = "Tags to be applied to resources"
   type        = map(string)


### PR DESCRIPTION
 for externally-managed deployments