### PR TITLE
DAPI-49 Allow Community-API to connect to Delius-API

### DIFF
--- a/security-groups/delius-api.tf
+++ b/security-groups/delius-api.tf
@@ -22,7 +22,7 @@ resource "aws_security_group_rule" "access_to_delius_api_lb" {
   protocol          = "tcp"
   from_port         = each.value
   to_port           = each.value
-  cidr_blocks       = local.user_access_cidr_blocks
+  cidr_blocks       = concat(local.bastion_public_ip, var.internal_moj_access_cidr_blocks)
   description       = "In from allowed IP ranges on port ${each.value}"
 }
 

--- a/security-groups/delius-api.tf
+++ b/security-groups/delius-api.tf
@@ -63,6 +63,16 @@ resource "aws_security_group_rule" "delius_api_instances_from_lb" {
   description              = "In from Delius API Load Balancer"
 }
 
+resource "aws_security_group_rule" "delius_api_instances_from_community_api" {
+  security_group_id        = aws_security_group.delius_api_instances.id
+  type                     = "ingress"
+  protocol                 = "tcp"
+  from_port                = 8080
+  to_port                  = 8080
+  source_security_group_id = aws_security_group.newtech_offenderapi_out.id
+  description              = "In from Community API"
+}
+
 resource "aws_security_group_rule" "delius_api_instances_to_db" {
   security_group_id        = aws_security_group.delius_api_instances.id
   type                     = "egress"

--- a/security-groups/newtech-offenderapi.tf
+++ b/security-groups/newtech-offenderapi.tf
@@ -16,6 +16,16 @@ resource "aws_security_group" "newtech_offenderapi_out" {
   }
 }
 
+resource "aws_security_group_rule" "newtech_offenderapi_delius_api" {
+  security_group_id        = aws_security_group.newtech_offenderapi_out.id
+  source_security_group_id = aws_security_group.delius_api_instances.id
+  type                     = "egress"
+  protocol                 = "tcp"
+  from_port                = "8080"
+  to_port                  = "8080"
+  description              = "New Tech Offender API Egress to Delius API"
+}
+
 resource "aws_security_group_rule" "newtech_offenderapi_db" {
   security_group_id        = aws_security_group.newtech_offenderapi_out.id
   source_security_group_id = aws_security_group.delius_db_in.id

--- a/security-groups/variables.tf
+++ b/security-groups/variables.tf
@@ -43,6 +43,11 @@ variable "vpc_supernet" {
   description = "VPC CIDR"
 }
 
+variable "internal_moj_access_cidr_blocks" {
+  description = "CIDRs for access via internal MOJ networks / VPNs"
+  type        = list(string)
+}
+
 variable "user_access_cidr_blocks" {
   description = "CIDRS for access via public/user network"
   type        = list(string)


### PR DESCRIPTION

The service discovery hostname (delius-api.ecs.cluster) should be used when connecting.