### PR TITLE
ALS-3340 Resolve Community-API CaseNotes certificate issue.

### DIFF
--- a/application/community-api/ecs.tf
+++ b/application/community-api/ecs.tf
@@ -19,7 +19,7 @@ module "ecs" {
     SPRING_LDAP_USERNAME       = data.terraform_remote_state.ldap.outputs.ldap_bind_user
     SPRING_LDAP_URLS           = "${data.terraform_remote_state.ldap.outputs.ldap_protocol}://${data.terraform_remote_state.ldap.outputs.private_fqdn_ldap_elb}:${data.terraform_remote_state.ldap.outputs.ldap_port}"
     ALFRESCO_BASEURL           = "https://alfresco.${data.terraform_remote_state.vpc.outputs.public_zone_name}/alfresco/s/noms-spg"
-    DELIUS_BASEURL             = "https://${data.terraform_remote_state.interface.outputs.private_fqdn_interface_wls_internal_alb}/api"
+    DELIUS_BASEURL             = "https://${data.terraform_remote_state.interface.outputs.public_fqdn_interface_wls_internal_alb}/api"
     # ... Add any environment variables here that should be pulled from Terraform data sources.
     #     Other environment variables are managed by CircleCI. See https://github.com/ministryofjustice/community-api/blob/main/.circleci/config.yml
   })

--- a/application/interface/output.tf
+++ b/application/interface/output.tf
@@ -10,6 +10,10 @@ output "private_fqdn_interface_wls_internal_alb" {
   value = module.interface.private_fqdn_internal_alb
 }
 
+output "public_fqdn_interface_wls_internal_alb" {
+  value = module.interface.public_fqdn_internal_alb
+}
+
 output "cloudwatch_log_group" {
   value = module.interface.cloudwatch_log_group
 }


### PR DESCRIPTION
Since the migration of NewTech services to hmpps-delius-core-terraform, NOMIS CaseNotes have been failing to insert into Delius as the URL was changed from the public to the private domain - causing a certificate mismatch. This change ensures the public domain is used.