### PR TITLE
Add support for exporting JMX metrics, and add WebLogic auto-scaling based on heap usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,8 @@ ln -s -f ../hmpps-env-configs env_configs
 ## Components
 ### Applications
 #### WebLogic Domains
-* [application/ndelius](application/ndelius) - National Delius application
-* [application/interface](application/interface) - National Delius API endpoints
-* [application/spg](application/spg) - Strategic Partner Gateway message broker - [Confluence Page](https://dsdmoj.atlassian.net/wiki/spaces/DAM/pages/2768438337/ActiveMQ)
+* [application/weblogic-app](application/weblogic-app) - National Delius application front-end
+* [application/weblogic-eis](application/weblogic-eis) - National Delius external interface services - API endpoints for IAPS, OASys, DSS etc.
 #### ECS Services - [Confluence Page](https://dsdmoj.atlassian.net/wiki/spaces/DAM/pages/3107979730/ECS+Cluster)
 * [application/pwm](application/pwm) - Password Reset Tool - [Confluence Page](https://dsdmoj.atlassian.net/wiki/spaces/DAM/pages/2116092086/PWM+-+Password+Reset)
 * [application/umt](application/umt) - User Management Tool

--- a/modules/ecs_service/adot-config.yml
+++ b/modules/ecs_service/adot-config.yml
@@ -1,0 +1,75 @@
+extensions:
+  health_check:
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:55681
+  awsxray:
+    endpoint: 0.0.0.0:2000
+    transport: udp
+  prometheus:
+    config:
+      scrape_configs:
+        - job_name: "ECS/ContainerInsights/Prometheus"
+          static_configs:
+            - targets: ["127.0.0.1:9404"]
+              labels:
+                ClusterName: "${cluster_name}"
+                ServiceName: "${service_name}"
+                TaskDefinitionFamily: "${task_definition_family}"
+
+processors:
+  batch/traces:
+    timeout: 1s
+    send_batch_size: 50
+  batch/metrics:
+    timeout: 60s
+  resource:
+    attributes:
+      - key: receiver # Insert receiver: prometheus for CloudWatch EMF Exporter to add prom_metric_type
+        value: "prometheus"
+        action: insert
+
+exporters:
+  awsxray:
+  awsemf/default:
+  awsemf/prometheus:
+    namespace: ECS/ContainerInsights/Prometheus # Use the exact namespace for builtin dashboard to work
+    log_group_name: "/aws/ecs/containerinsights/${cluster_name}/prometheus" # Log group name format is fixed as well, the only variable is cluster name
+    dimension_rollup_option: NoDimensionRollup
+    metric_declarations:
+      - dimensions: [ [ ClusterName, TaskDefinitionFamily, area ] ]
+        metric_name_selectors:
+          - "^jvm_memory_bytes_(committed|init|max|used)$"
+      - dimensions: [ [ ClusterName, TaskDefinitionFamily, pool ] ]
+        metric_name_selectors:
+          - "^jvm_memory_pool_bytes_(committed|init|max|used)$"
+      - dimensions: [ [ ClusterName, TaskDefinitionFamily ] ]
+        metric_name_selectors:
+          - "^jvm_threads_(current|daemon)$"
+          - "^jvm_classes_loaded$"
+          - "^java_lang_operatingsystem_(freephysicalmemorysize|totalphysicalmemorysize|freeswapspacesize|totalswapspacesize|systemcpuload|processcpuload|availableprocessors|openfiledescriptorcount)$"
+          - "^catalina_manager_(rejectedsessions|activesessions)$"
+          - "^jvm_gc_collection_seconds_(count|sum)$"
+          - "^catalina_globalrequestprocessor_(bytesreceived|bytessent|requestcount|errorcount|processingtime)$"
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp,awsxray]
+      processors: [batch/traces]
+      exporters: [awsxray]
+    metrics/otlp:
+      receivers: [otlp]
+      processors: [batch/metrics]
+      exporters: [awsemf/default]
+    metrics/prometheus:
+      receivers: [prometheus]
+      processors: [resource]
+      exporters: [awsemf/prometheus]
+
+  extensions: [health_check]

--- a/modules/ecs_service/alb.tf
+++ b/modules/ecs_service/alb.tf
@@ -6,9 +6,11 @@ resource "aws_lb_target_group" "target_group" {
   port     = var.service_port
 
   # Targets will be ECS tasks running in awsvpc mode so target_type needs to be ip
-  target_type          = "ip"
-  deregistration_delay = var.deregistration_delay
-  tags                 = merge(var.tags, { "Name" = "${local.name}-tg${var.target_group_count == 1 ? "" : count.index + 1}" })
+  target_type                   = "ip"
+  deregistration_delay          = var.deregistration_delay
+  load_balancing_algorithm_type = var.lb_algorithm_type
+
+  tags = merge(var.tags, { "Name" = "${local.name}-tg${var.target_group_count == 1 ? "" : count.index + 1}" })
 
   health_check {
     protocol            = "HTTP"

--- a/modules/ecs_service/autoscaling.tf
+++ b/modules/ecs_service/autoscaling.tf
@@ -13,7 +13,8 @@ resource "aws_appautoscaling_target" "scaling_target" {
   }
 }
 
-resource "aws_appautoscaling_policy" "scaling_policy" {
+resource "aws_appautoscaling_policy" "cpu_scaling_policy" {
+  count              = var.enable_cpu_scaling ? 1 : 0
   name               = "${local.name}-cpu-scaling-policy"
   policy_type        = "TargetTrackingScaling"
   resource_id        = aws_appautoscaling_target.scaling_target.resource_id
@@ -26,6 +27,24 @@ resource "aws_appautoscaling_policy" "scaling_policy" {
     }
 
     target_value     = var.target_cpu_usage
+    disable_scale_in = var.disable_scale_in
+  }
+}
+
+resource "aws_appautoscaling_policy" "mem_scaling_policy" {
+  count              = var.enable_mem_scaling ? 1 : 0
+  name               = "${local.name}-mem-scaling-policy"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.scaling_target.resource_id
+  scalable_dimension = aws_appautoscaling_target.scaling_target.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.scaling_target.service_namespace
+
+  target_tracking_scaling_policy_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "ECSServiceAverageMemoryUtilization"
+    }
+
+    target_value     = var.target_mem_usage
     disable_scale_in = var.disable_scale_in
   }
 }

--- a/modules/ecs_service/locals.tf
+++ b/modules/ecs_service/locals.tf
@@ -9,5 +9,9 @@ locals {
 
   # Get directory name for each additional log file
   additional_log_directories = { for name, path in var.additional_log_files : dirname(path) => name }
+
+  # Construct JAVA_TOOL_OPTIONS env var, with javaagent arguments for AWS OpenTelemetry and Prometheus JMX Exporter
+  jmx_exporter_port = 9404
+  java_tool_options = "${var.enable_telemetry && var.telemetry_use_java_tool_opts ? "-javaagent:/xray-agent/aws-opentelemetry-agent.jar " : ""}${var.enable_jmx_metrics ? "-javaagent:/jmx-exporter/jmx_prometheus_javaagent.jar=${local.jmx_exporter_port}:/jmx-exporter/config.yaml -Dcom.sun.management.jmxremote" : ""}"
 }
 

--- a/modules/ecs_service/variables.tf
+++ b/modules/ecs_service/variables.tf
@@ -92,24 +92,29 @@ variable "lb_stickiness_enabled" {
   default     = false
 }
 
+variable "lb_algorithm_type" {
+  description = "Corresponds to the load_balancing_algorithm_type setting on the automatically-created target groups. Determines the how the load balancer selects targets when routing requests. The value is round_robin or least_outstanding_requests."
+  default     = "round_robin"
+}
+
 variable "health_check_path" {
   default = "/"
 }
 
 variable "health_check_matcher" {
-  default = "200"
+  default = 200
 }
 
 variable "health_check_timeout" {
-  default = "5"
+  default = 5
 }
 
 variable "health_check_interval" {
-  default = "30"
+  default = 30
 }
 
 variable "health_check_healthy_threshold" {
-  default = "5"
+  default = 5
 }
 
 variable "health_check_unhealthy_threshold" {
@@ -131,8 +136,23 @@ variable "max_capacity" {
   default     = 10
 }
 
+variable "enable_cpu_scaling" {
+  description = "Whether to scale the service based on CPU usage."
+  default     = true
+}
+
 variable "target_cpu_usage" {
   description = "Target CPU usage (percentage). If the average CPU Utilization is above this value, the service will scale up. Otherwise it will scale down."
+  default     = 60
+}
+
+variable "enable_mem_scaling" {
+  description = "Whether to scale the service based on Memory usage."
+  default     = false
+}
+
+variable "target_mem_usage" {
+  description = "Target memory usage (percentage). If the average Memory Utilization is above this value, the service will scale up. Otherwise it will scale down."
   default     = 60
 }
 

--- a/modules/ecs_service/variables.tf
+++ b/modules/ecs_service/variables.tf
@@ -211,8 +211,13 @@ variable "enable_healthy_host_alarms" {
   default     = true
 }
 
+variable "enable_jmx_metrics" {
+  description = "Enable the JMX Exporter for Java/JVM-based applications, to push internal metrics to Prometheus/CloudWatch. Set to true to mount the /jmx-exporter volume onto the container and to update the JAVA_TOOL_OPTIONS environment variable to enable instrumentation."
+  default     = false
+}
+
 variable "enable_telemetry" {
-  description = "Enable AWS Open Telemetry Collector. Set to true to run the Telemetry daemon as a sidecar container, and to mount the /xray-agent volume onto the container. The JAVA_TOOL_OPTS environment variable is then used to instrument the Java application with the mounted agent library - use `var.telemetry_use_java_tool_opts` to change this behaviour."
+  description = "Enable AWS Open Telemetry Collector. Set to true to run the Telemetry daemon as a sidecar container, and to mount the /xray-agent volume onto the container. The JAVA_TOOL_OPTIONS environment variable is then used to instrument the Java application with the mounted agent library - use `var.telemetry_use_java_tool_opts` to change this behaviour."
   default     = false
 }
 

--- a/modules/nlb_to_alb/haproxy_asg.tf
+++ b/modules/nlb_to_alb/haproxy_asg.tf
@@ -51,6 +51,7 @@ resource "aws_autoscaling_group" "haproxy_asg" {
 
   lifecycle {
     create_before_destroy = true
+    ignore_changes        = [load_balancers, target_group_arns]
   }
 
   # Convert tag list to a map

--- a/modules/weblogic-admin-only/autoscaling.tf
+++ b/modules/weblogic-admin-only/autoscaling.tf
@@ -1,0 +1,63 @@
+resource "aws_appautoscaling_policy" "heap_scaling_out_policy" {
+  name               = "${var.short_environment_name}-${var.app_name}-heap-scale-out-policy"
+  policy_type        = "StepScaling"
+  resource_id        = module.ecs.autoscaling["resource_id"]
+  scalable_dimension = module.ecs.autoscaling["scalable_dimension"]
+  service_namespace  = module.ecs.autoscaling["service_namespace"]
+
+  step_scaling_policy_configuration {
+    adjustment_type         = "ChangeInCapacity"
+    metric_aggregation_type = "Average"
+    cooldown                = 600
+    step_adjustment {
+      metric_interval_lower_bound = 0
+      scaling_adjustment          = 1
+    }
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "heap_scaling_up_alarm" {
+  alarm_name          = "${var.short_environment_name}-${var.app_name}-heap-scale-out-alarm"
+  alarm_description   = "WebLogic heap usage percentage above threshold"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "2"
+  threshold           = 80 # Scale up above 80% heap usage
+  alarm_actions       = [aws_appautoscaling_policy.heap_scaling_out_policy.arn]
+
+  metric_query {
+    id          = "e1"
+    expression  = "100 * m1 / m2"
+    label       = "Heap Usage Percent"
+    return_data = "true"
+  }
+
+  metric_query {
+    id = "m1"
+    metric {
+      namespace   = "ECS/ContainerInsights/Prometheus"
+      metric_name = "jvm_memory_bytes_used"
+      stat        = "Average"
+      period      = 60
+      dimensions = {
+        ClusterName          = data.terraform_remote_state.ecs_cluster.outputs.shared_ecs_cluster_name
+        TaskDefinitionFamily = "${var.short_environment_name}-${var.app_name}-task-definition"
+        area                 = "heap"
+      }
+    }
+  }
+
+  metric_query {
+    id = "m2"
+    metric {
+      namespace   = "ECS/ContainerInsights/Prometheus"
+      metric_name = "jvm_memory_bytes_max"
+      stat        = "Average"
+      period      = 60
+      dimensions = {
+        ClusterName          = data.terraform_remote_state.ecs_cluster.outputs.shared_ecs_cluster_name
+        TaskDefinitionFamily = "${var.short_environment_name}-${var.app_name}-task-definition"
+        area                 = "heap"
+      }
+    }
+  }
+}

--- a/modules/weblogic-admin-only/ecs.tf
+++ b/modules/weblogic-admin-only/ecs.tf
@@ -53,10 +53,10 @@ module "ecs" {
   }, local.secrets)
 
   # Security & Networking
-  lb_stickiness_enabled            = true
-  health_check_path                = "/NDelius-war/delius/JSP/homepage.jsp"
-  health_check_matcher             = "200-399"
-  health_check_unhealthy_threshold = 10 # increased unhealthy threshold to allow longer for recovery, due to instances being stateful
+  lb_stickiness_enabled = true
+  lb_algorithm_type     = "least_outstanding_requests" # to send new sessions to fresh hosts after a scale-out
+  health_check_path     = "/NDelius-war/delius/JSP/healthcheck.jsp?ping"
+  health_check_timeout  = 15 # Should be greater than WebLogic's "Connection Reserve Timeout", which defaults to 10 seconds
   security_groups = concat(var.security_groups_instances, [
     data.terraform_remote_state.delius_core_security_groups.outputs.sg_common_out_id
   ])

--- a/modules/weblogic-admin-only/ecs.tf
+++ b/modules/weblogic-admin-only/ecs.tf
@@ -53,20 +53,22 @@ module "ecs" {
   }, local.secrets)
 
   # Security & Networking
-  lb_stickiness_enabled = true
-  lb_algorithm_type     = "least_outstanding_requests" # to send new sessions to fresh hosts after a scale-out
-  health_check_path     = "/NDelius-war/delius/JSP/healthcheck.jsp?ping"
-  health_check_timeout  = 15 # Should be greater than WebLogic's "Connection Reserve Timeout", which defaults to 10 seconds
+  lb_stickiness_enabled            = true
+  lb_algorithm_type                = "least_outstanding_requests" # to send new sessions to fresh hosts after a scale-out
+  health_check_path                = "/NDelius-war/delius/JSP/healthcheck.jsp?ping"
+  health_check_timeout             = 15 # Should be greater than WebLogic's "Connection Reserve Timeout", which defaults to 10 seconds
+  health_check_unhealthy_threshold = 10 # Increased unhealthy threshold to allow longer for recovery, due to instances being stateful
   security_groups = concat(var.security_groups_instances, [
     data.terraform_remote_state.delius_core_security_groups.outputs.sg_common_out_id
   ])
 
   # Monitoring
-  enable_telemetry  = true
-  create_lb_alarms  = true
-  load_balancer_arn = aws_lb.alb.arn
-  notification_arn  = data.terraform_remote_state.alerts.outputs.aws_sns_topic_alarm_notification_arn
-  log_error_pattern = "ERROR"
+  enable_jmx_metrics = true
+  enable_telemetry   = true
+  create_lb_alarms   = true
+  load_balancer_arn  = aws_lb.alb.arn
+  log_error_pattern  = "ERROR"
+  notification_arn   = data.terraform_remote_state.alerts.outputs.aws_sns_topic_alarm_notification_arn
 
   # Auto-Scaling
   disable_scale_in = true


### PR DESCRIPTION
Setting `enable_jmx_metrics = true` on any Java-based ECS service will internally expose Java MBean metrics in Prometheus format on port 9404. These metrics are then scraped by the AWS OpenTelemetry Collector sidecar container, and pushed to CloudWatch in AWS Embedded Metric Format. This automatically enables the built-in Java/JMX CloudWatch dashboard, and enables easy use of these metrics for alarms, auto-scaling etc.

The metrics can be found in the `ECS/ContainerInsights/Prometheus` namespace, and can be filtered per-cluster or per-service. For a full list of exported metrics, see: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights-Prometheus-metrics.html#ContainerInsights-Prometheus-metrics-jmx