### PR TITLE
ALS-2957 Set default placement strategy to AZ-balanced bin-pack

### DIFF
--- a/modules/ecs_service/ecs.tf
+++ b/modules/ecs_service/ecs.tf
@@ -162,6 +162,14 @@ resource "aws_ecs_service" "service" {
     }
   }
 
+  dynamic "ordered_placement_strategy" {
+    for_each = var.placement_strategy
+    content {
+      field = ordered_placement_strategy.value.field
+      type  = ordered_placement_strategy.value.type
+    }
+  }
+
   service_registries {
     registry_arn   = aws_service_discovery_service.web_svc_record.arn
     container_name = var.service_name

--- a/modules/ecs_service/variables.tf
+++ b/modules/ecs_service/variables.tf
@@ -161,6 +161,24 @@ variable "disable_scale_in" {
   default     = false
 }
 
+variable "placement_strategy" {
+  description = "Service level strategy rules that are taken into consideration during task placement. List from top to bottom in order of precedence. Defaults to AZ-balanced binpack. See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement-strategies.html"
+  type = list(object({
+    field = string
+    type  = string
+  }))
+  default = [
+    {
+      type  = "spread"
+      field = "attribute:ecs.availability-zone"
+    },
+    {
+      type  = "binpack"
+      field = "memory"
+    }
+  ]
+}
+
 variable "deregistration_delay" {
   description = "Number of seconds to spend draining tasks"
   default     = 60


### PR DESCRIPTION
to save on EC2 costs while maintaining service reliability/resilience.