### PR TITLE
Disable response code alarms for WebLogic

### DIFF
--- a/modules/weblogic-admin-only/ecs.tf
+++ b/modules/weblogic-admin-only/ecs.tf
@@ -65,13 +65,14 @@ module "ecs" {
   ])
 
   # Monitoring
-  enable_jmx_metrics  = true
-  jmx_exporter_config = "/home/oracle/.jmx-exporter/jmx-exporter.yml"
-  enable_telemetry    = true
-  create_lb_alarms    = true
-  load_balancer_arn   = aws_lb.alb.arn
-  log_error_pattern   = "FATAL"
-  notification_arn    = data.terraform_remote_state.alerts.outputs.aws_sns_topic_alarm_notification_arn
+  enable_jmx_metrics          = true
+  jmx_exporter_config         = "/home/oracle/.jmx-exporter/jmx-exporter.yml"
+  enable_telemetry            = true
+  create_lb_alarms            = true
+  load_balancer_arn           = aws_lb.alb.arn
+  enable_response_code_alarms = false # 500 responses are sometimes returned for normal operations e.g. OASys offender not found
+  log_error_pattern           = "FATAL"
+  notification_arn            = data.terraform_remote_state.alerts.outputs.aws_sns_topic_alarm_notification_arn
 
   # Auto-Scaling
   disable_scale_in   = true  # Sessions are stored in-memory - see lambda.tf for nightly scheduled scale-in function


### PR DESCRIPTION
This will tidy up the noise that's started appearing in Slack today.