### PR TITLE
Disable response time alarms for WebLogic EIS service

### DIFF
--- a/application/weblogic-eis/weblogic.tf
+++ b/application/weblogic-eis/weblogic.tf
@@ -23,5 +23,7 @@ module "weblogic" {
     data.terraform_remote_state.delius_core_security_groups.outputs.sg_weblogic_interface_instances_id,
     data.terraform_remote_state.delius_core_security_groups.outputs.sg_umt_auth_id
   ]
+
+  enable_response_time_alarms = false # Response times can exceed 1s during normal use (e.g. during the daily DSS import)
 }
 

--- a/modules/weblogic-admin-only/ecs.tf
+++ b/modules/weblogic-admin-only/ecs.tf
@@ -71,6 +71,7 @@ module "ecs" {
   create_lb_alarms            = true
   load_balancer_arn           = aws_lb.alb.arn
   enable_response_code_alarms = false # 500 responses are sometimes returned for normal operations e.g. OASys offender not found
+  enable_response_time_alarms = var.enable_response_time_alarms
   log_error_pattern           = "FATAL"
   notification_arn            = data.terraform_remote_state.alerts.outputs.aws_sns_topic_alarm_notification_arn
 

--- a/modules/weblogic-admin-only/variables.tf
+++ b/modules/weblogic-admin-only/variables.tf
@@ -42,6 +42,11 @@ variable "security_groups_instances" {
   default     = []
 }
 
+variable "enable_response_time_alarms" {
+  description = "Enable or disable standard alarms for response times."
+  default     = true
+}
+
 variable "tags" {
   description = "Tags to be applied to resources"
   type        = map(string)


### PR DESCRIPTION
to reduce noise during daily DSS import etc