### PR TITLE
PI-53 Add POC Lambda to read messages from MOJ Cloud Platform

### DIFF
--- a/domain-events/iam.tf
+++ b/domain-events/iam.tf
@@ -1,0 +1,31 @@
+data "aws_iam_policy_document" "assume_role_policy_document" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+# Provides receive message, delete message, and read attribute access to SQS queues, and write permissions to CloudWatch logs.
+data "aws_iam_policy" "AWSLambdaSQSQueueExecutionRole" {
+  arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaSQSQueueExecutionRole"
+}
+
+resource "aws_iam_role" "lambda_exec_role" {
+  name               = "${var.environment_name}-cp-sqs-consumer"
+  assume_role_policy = data.aws_iam_policy_document.assume_role_policy_document.json
+  managed_policy_arns = [
+    data.aws_iam_policy.AWSLambdaSQSQueueExecutionRole.arn
+  ]
+  tags = merge(var.tags, { Name = "${var.environment_name}-cp-sqs-consumer" })
+}
+
+output "lambda_exec_role" {
+  value = {
+    arn  = aws_iam_role.lambda_exec_role.arn
+    name = aws_iam_role.lambda_exec_role.name
+  }
+}

--- a/domain-events/lambda/pre-sentence-report-handler.py
+++ b/domain-events/lambda/pre-sentence-report-handler.py
@@ -1,0 +1,8 @@
+# Upload Pre-Sentence Report documents to Delius/Alfresco in response to events from the
+# [Pre-Sentence Service](https://github.com/ministryofjustice/pre-sentence-service).
+
+
+# TODO - this is just a placeholder for now, to prove messaging works
+def handler(event, context):
+    print(event)
+    print(context)

--- a/domain-events/locals.tf
+++ b/domain-events/locals.tf
@@ -1,0 +1,8 @@
+locals {
+  # Mapping from Delius environment name to Cloud Platform namespace
+  cp_namespace = lookup({
+    delius-test     = "dev"
+    delius-pre-prod = "preprod"
+    delius-prod     = "prod"
+  }, var.environment_name, "")
+}

--- a/domain-events/pre-sentence-report-handler.tf
+++ b/domain-events/pre-sentence-report-handler.tf
@@ -1,0 +1,24 @@
+data "archive_file" "pre_sentence_report_handler" {
+  type        = "zip"
+  output_path = "${path.module}/files/pre-sentence-report-handler.zip"
+  source {
+    content  = file("${path.module}/lambda/pre-sentence-report-handler.py")
+    filename = "lambda.py"
+  }
+}
+
+resource "aws_lambda_function" "pre_sentence_report_handler" {
+  function_name    = "${var.environment_name}-pre-sentence-report-handler"
+  role             = aws_iam_role.lambda_exec_role.arn
+  runtime          = "python3.8"
+  handler          = "lambda.handler"
+  filename         = data.archive_file.pre_sentence_report_handler.output_path
+  source_code_hash = filebase64sha256(data.archive_file.pre_sentence_report_handler.output_path)
+  tags             = merge(var.tags, { Name = "${var.environment_name}-pre-sentence-report-handler" })
+}
+
+resource "aws_lambda_event_source_mapping" "pre_sentence_report_handler" {
+  count            = local.cp_namespace != "" ? 1 : 0
+  function_name    = aws_lambda_function.pre_sentence_report_handler.function_name
+  event_source_arn = "arn:aws:sqs:eu-west-2:754256621582:Digital-Prison-Services-${local.cp_namespace}-pre_sentence_report_hmpps_queue"
+}

--- a/domain-events/terragrunt.hcl
+++ b/domain-events/terragrunt.hcl
@@ -1,0 +1,3 @@
+include {
+  path = find_in_parent_folders()
+}

--- a/domain-events/variables.tf
+++ b/domain-events/variables.tf
@@ -1,0 +1,2 @@
+variable "environment_name" {}
+variable "tags" { type = map(string) }

--- a/domain-events/versions.tf
+++ b/domain-events/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Adds a dummy Lambda function that listens to the `pre_sentence_report_hmpps_queue` in MOJ Cloud Platform.  Currently, this Lambda simply logs the message to CloudWatch, however it is intended to handle PSR completion events by uploading files to Alfresco.

Also creates a shared `cp-sqs-consumer` IAM role that can be re-used for any Lambda function that needs to read from Cloud Platform SQS queues.  This role must be specified in the SQS queue policy, see: https://github.com/ministryofjustice/cloud-platform-environments/blob/main/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-dev/resources/hmpps-pre-sentence-report-queue.tf#L63