### PR TITLE
Increment oracle-database module version for ebs optimisation

### DIFF
--- a/database_failover/server-delius-db-1.tf
+++ b/database_failover/server-delius-db-1.tf
@@ -9,7 +9,7 @@ locals {
 }
 
 module "delius_db_1" {
-  source      = "git::https://github.com/ministryofjustice/hmpps-oracle-database.git//modules/oracle-database?ref=2.1.0"
+  source      = "git::https://github.com/ministryofjustice/hmpps-oracle-database.git//modules/oracle-database?ref=2.6.0"
   server_name = "delius-db-1"
 
   ami_id               = data.aws_ami.centos_oracle_db.id

--- a/database_standbydb1/server-delius-db-2.tf
+++ b/database_standbydb1/server-delius-db-2.tf
@@ -1,5 +1,5 @@
 module "delius_db_2" {
-  source      = "git::https://github.com/ministryofjustice/hmpps-oracle-database.git//modules/oracle-database?ref=2.1.0"
+  source      = "git::https://github.com/ministryofjustice/hmpps-oracle-database.git//modules/oracle-database?ref=2.6.0"
   server_name = "delius-db-2"
 
   ami_id               = data.aws_ami.centos_oracle_db.id

--- a/database_standbydb2/server-delius-db-3.tf
+++ b/database_standbydb2/server-delius-db-3.tf
@@ -1,5 +1,5 @@
 module "delius_db_3" {
-  source      = "git::https://github.com/ministryofjustice/hmpps-oracle-database.git//modules/oracle-database?ref=2.1.0"
+  source      = "git::https://github.com/ministryofjustice/hmpps-oracle-database.git//modules/oracle-database?ref=2.6.0"
   server_name = "delius-db-3"
 
   ami_id               = data.aws_ami.centos_oracle_db.id


### PR DESCRIPTION
Work item: https://dsdmoj.atlassian.net/browse/NIT-161
Related to oracle-database change - https://github.com/ministryofjustice/hmpps-oracle-database/pull/19
And env_configs change - https://github.com/ministryofjustice/hmpps-env-configs/pull/2004

This change will allow delius-dbs to be configured using the new work in oracle-database module that parameterises ebs volume type and related properties.