### PR TITLE
PI-277 Shorten the name of the housekeeping service

### DIFF
--- a/application/probation-integration-services/housekeeping.tf
+++ b/application/probation-integration-services/housekeeping.tf
@@ -7,7 +7,7 @@ module "housekeeping" {
   tags                     = var.tags
 
   # Application Container
-  service_name                   = "probation-integration-housekeeping"
+  service_name                   = "integration-housekeeping"
   ignore_task_definition_changes = true
 
   # Security & Networking


### PR DESCRIPTION
The limit on IAM role name length is 64 characters, which was exceeded in training-test: "dtt-training-test-probation-integration-housekeeping-ecs-exec-role"