### PR TITLE
NIT-211 autostop-<env> tag to Phase1

### DIFF
--- a/application/gdpr/rds.tf
+++ b/application/gdpr/rds.tf
@@ -52,7 +52,7 @@ resource "aws_db_instance" "primary" {
   backup_window             = local.app_config["db_backup_window"]
   final_snapshot_identifier = "${var.environment_name}-final-snapshot"
 
-  tags = merge(var.tags, { Name = "${local.app_name}-primary-db" })
+  tags = merge(var.tags, { Name = "${local.app_name}-primary-db", "autostop-${var.environment_type}" = "Phase1" })
 
   lifecycle {
     ignore_changes = [engine_version] # Allow automated minor version upgrades

--- a/application/gdpr/variables.tf
+++ b/application/gdpr/variables.tf
@@ -14,6 +14,10 @@ variable "short_environment_name" {
   description = "Shortened environment name to be used as a unique identifier for resources with a limit on resource name length - eg. dlc-dev"
 }
 
+variable "environment_type" {
+  description = "Environment type to be used as a unique identifier for resources - eg. dev or pre-prod"
+}
+
 variable "project_name" {
   description = "Project name to be used when looking up SSM parameters - eg. delius-core"
 }

--- a/application/merge/rds.tf
+++ b/application/merge/rds.tf
@@ -50,7 +50,7 @@ resource "aws_db_instance" "primary" {
   backup_window             = local.app_config["db_backup_window"]
   final_snapshot_identifier = "${var.environment_name}-final-snapshot"
 
-  tags = merge(var.tags, { Name = "${local.app_name}-primary-db" })
+  tags = merge(var.tags, { Name = "${local.app_name}-primary-db", "autostop-${var.environment_type}" = "Phase1" })
 
   lifecycle {
     ignore_changes = [engine_version] # Allow automated minor version upgrades

--- a/application/merge/variables.tf
+++ b/application/merge/variables.tf
@@ -14,6 +14,10 @@ variable "short_environment_name" {
   description = "Shortened environment name to be used as a unique identifier for resources with a limit on resource name length - eg. dlc-dev"
 }
 
+variable "environment_type" {
+  description = "Environment type to be used as a unique identifier for resources - eg. dev or pre-prod"
+}
+
 variable "project_name" {
   description = "Project name to be used when looking up SSM parameters - eg. delius-core"
 }


### PR DESCRIPTION
Phase1 occurs 1st when starting services, and 2nd when stopping. Original values meant that if auto start/stop was enabled in the environment, RDS databases could be shut down when apps are still running, which could result in data loss.
Setting Phase1 across all environments does not mean that databases will be shut down over night. RDS DB schedules are disabled at the lambda level