### PR TITLE
Create ECS service for 443-test

### DIFF
--- a/application/probation-integration-services/443-test.tf
+++ b/application/probation-integration-services/443-test.tf
@@ -1,0 +1,32 @@
+module "443-test" {
+  source                   = "../../modules/ecs_service"
+  region                   = var.region
+  environment_name         = var.environment_name
+  short_environment_name   = var.short_environment_name
+  remote_state_bucket_name = var.remote_state_bucket_name
+  tags                     = var.tags
+
+  # Application Container
+  service_name                   = "443-test"
+  ignore_task_definition_changes = true
+
+  # Security & Networking
+  task_role_arn      = aws_iam_role.ecs_sqs_task.arn
+  target_group_count = 0 # no load balancer required
+  security_groups = [
+    data.terraform_remote_state.delius_core_security_groups.outputs.sg_common_out_id,
+    data.terraform_remote_state.delius_core_security_groups.outputs.sg_delius_db_access_id
+  ]
+
+  # Monitoring
+  notification_arn = data.terraform_remote_state.alerts.outputs.aws_sns_topic_alarm_notification_arn
+
+  # Scaling
+  min_capacity = local.min_capacity
+  max_capacity = local.max_capacity
+}
+
+resource "aws_iam_role_policy_attachment" "443-test" {
+  role       = module.443-test.exec_role.name
+  policy_arn = aws_iam_policy.access_ssm_parameters.arn
+}


### PR DESCRIPTION
Automated changes by [hmpps-probation-integration-services](https://github.com/ministryofjustice/hmpps-probation-integration-services/actions/workflows/bootstrap.yml)