### PR TITLE
adding cloud platform ingress to delius db sec group

### DIFF
--- a/security-groups/delius-db-in.tf
+++ b/security-groups/delius-db-in.tf
@@ -309,3 +309,13 @@ resource "aws_security_group_rule" "delius_performance_test_ci_db_in_1521" {
   source_security_group_id = data.terraform_remote_state.ci_delius_core.outputs.performance_tests["security_group"]["id"]
   description              = "CI - Delius Performance Tests in 1521"
 }
+
+resource "aws_security_group_rule" "cloud_platform_db_in_1521" {
+  security_group_id        = aws_security_group.delius_db_in.id
+  type                     = "ingress"
+  protocol                 = "tcp"
+  from_port                = 1521
+  to_port                  = 1521
+  cidr_blocks              = [var.cloudplatform_data.cidr_range]
+  description              = "Ingress from Cloud Platform to Delius DB"
+}

--- a/security-groups/variables.tf
+++ b/security-groups/variables.tf
@@ -95,3 +95,7 @@ variable "community_api_ingress" {
   default     = []
 }
 
+variable "cloudplatform_data" {
+  description = "Data about cloud platform"
+  type        = map(string)
+}


### PR DESCRIPTION
Work item: https://dsdmoj.atlassian.net/browse/NIT-365

Adding in security group rule to permit connectivity from cloud platform CIDR to delius dbs.
(Note, network connectivity would also depend on correct routing to/from TGW too)