### PR TITLE
Upgrade lambda nodejs version to v16

### DIFF
--- a/alerts/lambda.tf
+++ b/alerts/lambda.tf
@@ -1,3 +1,4 @@
+## Lambda function <env>-notify-delius-core-slack-channel-alarm
 resource "aws_lambda_function" "notify_slack_alarm" {
   runtime          = "nodejs16.x"
   role             = aws_iam_role.lambda_role.arn
@@ -26,6 +27,7 @@ resource "aws_lambda_permission" "sns_alarm" {
   source_arn    = aws_sns_topic.alarm_notification.arn
 }
 
+## Lambda function <env>-notify-delius-core-slack-channel-batch
 resource "aws_lambda_function" "notify_slack_batch" {
   runtime          = "nodejs16.x"
   role             = aws_iam_role.lambda_role.arn

--- a/alerts/lambda.tf
+++ b/alerts/lambda.tf
@@ -1,5 +1,5 @@
 resource "aws_lambda_function" "notify_slack_alarm" {
-  runtime          = "nodejs12.x"
+  runtime          = "nodejs16.x"
   role             = aws_iam_role.lambda_role.arn
   filename         = data.archive_file.alarm_lambda_handler_zip.output_path
   function_name    = local.lambda_name_alarm
@@ -27,7 +27,7 @@ resource "aws_lambda_permission" "sns_alarm" {
 }
 
 resource "aws_lambda_function" "notify_slack_batch" {
-  runtime          = "nodejs12.x"
+  runtime          = "nodejs16.x"
   role             = aws_iam_role.lambda_role.arn
   filename         = data.archive_file.batch_lambda_handler_zip.output_path
   function_name    = local.lambda_name_batch


### PR DESCRIPTION
AWS provider upgraded to v3 in order to be able to upgrade lambda nodejs version to v16.
Lambda functions:
- <env>-notify-delius-core-slack-channel-alarm
- <env>-notify-delius-core-slack-channel-batch

Ticket no. https://dsdmoj.atlassian.net/browse/NIT-344