### PR TITLE
Add login page path pattern for JSP redirect rule

### DIFF
--- a/application/weblogic-app/jsp-redirect-rule.tf
+++ b/application/weblogic-app/jsp-redirect-rule.tf
@@ -4,7 +4,7 @@ resource "aws_lb_listener_rule" "jsp_redirect_listener_rule" {
   priority     = 2
   condition {
     path_pattern {
-      values = ["/NDelius*.jsp"]
+      values = ["/NDelius*.jsp","/NDelius*login.jsp*"]
     }
   }
   action {


### PR DESCRIPTION
There are a number of users who seemingly have the old login page bookmarked, but with special/hidden characters at the end. Adding this path pattern catches those and redirects them to the new login page.