### PR TITLE
DBA-897

### DIFF
--- a/database_standbydb1/server-delius-db-2.tf
+++ b/database_standbydb1/server-delius-db-2.tf
@@ -1,5 +1,12 @@
 locals {
   migrated_envs = ["delius-mis-dev"]
+
+  tags = merge(
+    var.tags,
+    {
+      "autostop-${var.environment_type}" = var.delius_overide_autostop_tags
+    },
+  )
 }
 
 module "delius_db_2" {

--- a/database_standbydb1/variables.tf
+++ b/database_standbydb1/variables.tf
@@ -56,3 +56,6 @@ variable "db_size_delius_core" {
   type        = map(string)
 }
 
+variable "delius_overide_autostop_tags" {
+  default = "False"
+}

--- a/database_standbydb2/server-delius-db-3.tf
+++ b/database_standbydb2/server-delius-db-3.tf
@@ -1,5 +1,12 @@
 locals {
   migrated_envs = ["delius-mis-dev"]
+
+  tags = merge(
+    var.tags,
+    {
+      "autostop-${var.environment_type}" = var.delius_overide_autostop_tags
+    },
+  )
 }
 
 module "delius_db_3" {

--- a/database_standbydb2/variables.tf
+++ b/database_standbydb2/variables.tf
@@ -56,3 +56,6 @@ variable "db_size_delius_core" {
   type        = map(string)
 }
 
+variable "delius_overide_autostop_tags" {
+  default = "False"
+}


### PR DESCRIPTION
Use delius_overide_autostop_tags to set the autostop tags on the standby databases (already used for the primary). This should ensure that the override flag defined in mis-dev is applied to the delius-standby instances so that they don't auto-start after being manually shutdown.