### PR TITLE
DBA-897

### DIFF
--- a/database_standbydb1/server-delius-db-2.tf
+++ b/database_standbydb1/server-delius-db-2.tf
@@ -26,7 +26,7 @@ module "delius_db_2" {
     data.terraform_remote_state.vpc_security_groups.outputs.sg_delius_core_db_in_from_mis_id,
   ]
 
-  tags                         = var.tags
+  tags                         = local.tags
   environment_name             = data.terraform_remote_state.vpc.outputs.environment_name
   bastion_inventory            = data.terraform_remote_state.vpc.outputs.bastion_inventory
   project_name                 = var.project_name

--- a/database_standbydb2/server-delius-db-3.tf
+++ b/database_standbydb2/server-delius-db-3.tf
@@ -26,7 +26,7 @@ module "delius_db_3" {
     data.terraform_remote_state.vpc_security_groups.outputs.sg_delius_core_db_in_from_mis_id,
   ]
 
-  tags                         = var.tags
+  tags                         = local.tags
   environment_name             = data.terraform_remote_state.vpc.outputs.environment_name
   bastion_inventory            = data.terraform_remote_state.vpc.outputs.bastion_inventory
   project_name                 = var.project_name


### PR DESCRIPTION
Need to use "local.tags" in the db module instead of "var.tags" so that the local tags variable with autostop added is used.