### PR TITLE
disable telemetry for pwm

### DIFF
--- a/application/pwm/ecs.tf
+++ b/application/pwm/ecs.tf
@@ -39,7 +39,7 @@ module "service" {
 
   # Monitoring
   notification_arn  = data.terraform_remote_state.alerts.outputs.aws_sns_topic_alarm_notification_arn
-  enable_telemetry  = true
+  enable_telemetry  = false
   create_lb_alarms  = true
   load_balancer_arn = aws_lb.alb.arn
   log_error_pattern = "FATAL"


### PR DESCRIPTION
Telemetry is broken and causing the service to break. Disabling for the time being.